### PR TITLE
Monument Slugs WIP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     runtimeOnly('org.springframework.boot:spring-boot-devtools')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     implementation('me.alidg:errors-spring-boot-starter:1.2.0')
+    implementation group: 'com.github.slugify', name: 'slugify', version: '2.4'
 }
 
 node {

--- a/src/main/java/com/monumental/listeners/MonumentListener.java
+++ b/src/main/java/com/monumental/listeners/MonumentListener.java
@@ -1,0 +1,20 @@
+package com.monumental.listeners;
+
+import com.monumental.models.Monument;
+import org.hibernate.event.spi.PreInsertEvent;
+import org.hibernate.event.spi.PreInsertEventListener;
+
+public class MonumentListener implements PreInsertEventListener {
+
+    @Override
+    public boolean onPreInsert(PreInsertEvent event) {
+        if (!(event.getEntity() instanceof Monument)) {
+            return false;
+        }
+
+        Monument monument = (Monument) event.getEntity();
+        monument.setSlug("slug");
+
+        return false;
+    }
+}

--- a/src/main/java/com/monumental/listeners/MonumentListener.java
+++ b/src/main/java/com/monumental/listeners/MonumentListener.java
@@ -1,10 +1,17 @@
 package com.monumental.listeners;
 
 import com.monumental.models.Monument;
+import com.monumental.services.MonumentService;
 import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class MonumentListener implements PreInsertEventListener {
+
+    @Autowired
+    MonumentService monumentService;
 
     @Override
     public boolean onPreInsert(PreInsertEvent event) {
@@ -13,7 +20,7 @@ public class MonumentListener implements PreInsertEventListener {
         }
 
         Monument monument = (Monument) event.getEntity();
-        monument.setSlug("slug");
+        monumentService.generateSlug(monument);
 
         return false;
     }

--- a/src/main/java/com/monumental/listeners/MonumentListener.java
+++ b/src/main/java/com/monumental/listeners/MonumentListener.java
@@ -33,22 +33,18 @@ public class MonumentListener implements PreInsertEventListener, PreUpdateEventL
 
     @Override
     public boolean onPreUpdate(PreUpdateEvent event) {
-        try {
-            if (!(event.getEntity() instanceof Monument)) {
-                return false;
-            }
+        if (!(event.getEntity() instanceof Monument)) {
+            return false;
+        }
 
-            Monument updatedMonument = (Monument) event.getEntity();
-            Monument existingMonument = monumentService.get(updatedMonument.getId());
+        Monument updatedMonument = (Monument) event.getEntity();
+        Monument existingMonument = monumentService.get(updatedMonument.getId());
 
-            // This event apparently gets called on insert sometimes, so this skips if there is no existing record
-            if (existingMonument == null) return false;
+        // This event apparently gets called on insert sometimes, so this skips if there is no existing record
+        if (existingMonument == null) return false;
 
-            if (monumentService.slugChanged(existingMonument, updatedMonument)) {
-                monumentService.generateSlug(updatedMonument);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (monumentService.slugChanged(existingMonument, updatedMonument)) {
+            monumentService.generateSlug(updatedMonument);
         }
 
         return false;

--- a/src/main/java/com/monumental/listeners/MonumentListener.java
+++ b/src/main/java/com/monumental/listeners/MonumentListener.java
@@ -4,23 +4,52 @@ import com.monumental.models.Monument;
 import com.monumental.services.MonumentService;
 import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MonumentListener implements PreInsertEventListener {
+public class MonumentListener implements PreInsertEventListener, PreUpdateEventListener {
 
     @Autowired
     MonumentService monumentService;
 
+    /**
+     * Before a Monument is inserted, generate its slug
+     */
     @Override
     public boolean onPreInsert(PreInsertEvent event) {
+        // This event is called for all inserts so filter out non-Monuments
         if (!(event.getEntity() instanceof Monument)) {
             return false;
         }
 
         Monument monument = (Monument) event.getEntity();
         monumentService.generateSlug(monument);
+
+        return false;
+    }
+
+    @Override
+    public boolean onPreUpdate(PreUpdateEvent event) {
+        try {
+            if (!(event.getEntity() instanceof Monument)) {
+                return false;
+            }
+
+            Monument updatedMonument = (Monument) event.getEntity();
+            Monument existingMonument = monumentService.get(updatedMonument.getId());
+
+            // This event apparently gets called on insert sometimes, so this skips if there is no existing record
+            if (existingMonument == null) return false;
+
+            if (monumentService.slugChanged(existingMonument, updatedMonument)) {
+                monumentService.generateSlug(updatedMonument);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
         return false;
     }

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -22,7 +22,6 @@ import java.util.Date;
 public class Monument extends Model implements Serializable {
 
     @Column(name = "slug", unique = true)
-    @NaturalId
     private String slug;
 
     @Column(name = "submitted_by")

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -1,5 +1,7 @@
 package com.monumental.models;
 
+import org.hibernate.annotations.NaturalId;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -18,6 +20,10 @@ import java.util.Date;
     @UniqueConstraint(columnNames = "id")
 })
 public class Monument extends Model implements Serializable {
+
+    @Column(name = "slug", unique = true)
+    @NaturalId
+    private String slug;
 
     @Column(name = "submitted_by")
     private String submittedBy;
@@ -62,6 +68,14 @@ public class Monument extends Model implements Serializable {
         this.lon = lon;
         this.city = city;
         this.state = state;
+    }
+
+    public String getSlug() {
+        return this.slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
     }
 
     public String getSubmittedBy() {

--- a/src/main/java/com/monumental/services/ModelService.java
+++ b/src/main/java/com/monumental/services/ModelService.java
@@ -2,6 +2,7 @@ package com.monumental.services;
 
 import com.monumental.models.Model;
 import org.hibernate.HibernateException;
+import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -91,4 +91,13 @@ public class MonumentService extends ModelService<Monument> {
 
         return records;
     }
+
+    /**
+     * Checks if a Monument's slug has changed
+     */
+    public boolean slugChanged(Monument existing, Monument updated) {
+        return !existing.getTitle().equals(updated.getTitle()) ||
+               !existing.getCity().equals(updated.getCity()) ||
+               !existing.getState().equals(updated.getState());
+    }
 }

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -1,10 +1,19 @@
 package com.monumental.services;
 
+import com.github.slugify.Slugify;
 import com.monumental.models.Monument;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 public class MonumentService extends ModelService<Monument> {
+
+    static Slugify slugify = new Slugify();
 
     /**
      * Public constructor for MonumentService
@@ -22,5 +31,65 @@ public class MonumentService extends ModelService<Monument> {
 
     }
 
-    // Add Monument specific database operations here if needed
+    /**
+     * Generate a unique slug for the given monument
+     * @param monument  Monument to generate a slug for
+     */
+    public void generateSlug(Monument monument) {
+
+        List<Monument> duplicates;
+        try {
+            System.out.println("getting duplicates");
+            duplicates = getPossibleSlugDuplicates(monument);
+        } catch (HibernateException e) {
+            System.err.println("Hibernate Exception occurred while finding duplicate slugs");
+            throw e;
+        }
+
+        System.out.println("got duplicates");
+
+        // Generate the slug from the Monument's title, city, and state
+        List<String> slugParts = Arrays.asList(monument.getTitle(), monument.getCity(), monument.getState());
+        // If these fields do not create a unique key, add on an additional identifier to make it unique
+        if (duplicates.size() > 0) slugParts.add(String.valueOf(duplicates.size()));
+
+        // Use the Slugify package to create a nice, readable slug from these fields
+        monument.setSlug(slugify.slugify(String.join(" ", slugParts)));
+    }
+
+    /**
+     * Queries for Monuments with matching title, city, and state, since these conditions could lead to duplicate slugs
+     * The query excludes the Id of the reference monument so that only other Monuments are returned
+     * @param monument  The reference Monument to check for possible slug duplicates of
+     * @return          Matching monuments that were found which would lead to duplicate slugs
+     * @throws HibernateException   Thrown upon query exception
+     */
+    @SuppressWarnings("unchecked")
+    public List<Monument> getPossibleSlugDuplicates(Monument monument) throws HibernateException {
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<Monument> records;
+
+        try {
+            transaction = session.beginTransaction();
+            String queryString = "FROM " + Monument.class.getName() +
+                    "WHERE title = '" + monument.getTitle() + "' " +
+                    "AND city = '" + monument.getCity() + "' " +
+                    "AND state = '" + monument.getState() + "'";
+            if (monument.getId() != null) {
+                queryString += " AND id != " + monument.getId();
+            }
+            records = session.createQuery(queryString).list();
+            transaction.commit();
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            throw e;
+        }
+
+        return records;
+    }
 }

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -7,6 +7,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,17 +40,14 @@ public class MonumentService extends ModelService<Monument> {
 
         List<Monument> duplicates;
         try {
-            System.out.println("getting duplicates");
             duplicates = getPossibleSlugDuplicates(monument);
         } catch (HibernateException e) {
             System.err.println("Hibernate Exception occurred while finding duplicate slugs");
             throw e;
         }
 
-        System.out.println("got duplicates");
-
         // Generate the slug from the Monument's title, city, and state
-        List<String> slugParts = Arrays.asList(monument.getTitle(), monument.getCity(), monument.getState());
+        ArrayList<String> slugParts = new ArrayList<>(Arrays.asList(monument.getTitle(), monument.getCity(), monument.getState()));
         // If these fields do not create a unique key, add on an additional identifier to make it unique
         if (duplicates.size() > 0) slugParts.add(String.valueOf(duplicates.size()));
 
@@ -72,13 +70,14 @@ public class MonumentService extends ModelService<Monument> {
 
         try {
             transaction = session.beginTransaction();
-            String queryString = "FROM " + Monument.class.getName() +
+            String queryString = "FROM Monument " +
                     "WHERE title = '" + monument.getTitle() + "' " +
                     "AND city = '" + monument.getCity() + "' " +
                     "AND state = '" + monument.getState() + "'";
             if (monument.getId() != null) {
                 queryString += " AND id != " + monument.getId();
             }
+
             records = session.createQuery(queryString).list();
             transaction.commit();
             session.close();

--- a/src/main/java/com/monumental/services/SessionFactoryService.java
+++ b/src/main/java/com/monumental/services/SessionFactoryService.java
@@ -54,5 +54,6 @@ public class SessionFactoryService {
     public void registerListeners() {
         EventListenerRegistry registry = ((SessionFactoryImpl) this.factory).getServiceRegistry().getService(EventListenerRegistry.class);
         registry.getEventListenerGroup(EventType.PRE_INSERT).appendListener(monumentListener);
+        registry.getEventListenerGroup(EventType.PRE_UPDATE).appendListener(monumentListener);
     }
 }

--- a/src/main/java/com/monumental/services/SessionFactoryService.java
+++ b/src/main/java/com/monumental/services/SessionFactoryService.java
@@ -7,8 +7,12 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.service.ServiceRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 @Service
 public class SessionFactoryService {
@@ -29,8 +33,6 @@ public class SessionFactoryService {
             }
             ServiceRegistry registry = new StandardServiceRegistryBuilder().applySettings(conf.getProperties()).build();
             this.factory = conf.buildSessionFactory(registry);
-            EventListenerRegistry listenerRegistry = registry.getService(EventListenerRegistry.class);
-            listenerRegistry.getEventListenerGroup(EventType.PRE_INSERT).appendListener(new MonumentListener());
         } catch (Throwable ex) {
             System.err.println("Initial SessionFactory creation failed." + ex);
             throw new ExceptionInInitializerError(ex);
@@ -39,5 +41,18 @@ public class SessionFactoryService {
 
     public SessionFactory getFactory() {
         return this.factory;
+    }
+
+    @Autowired
+    private MonumentListener monumentListener;
+
+    /**
+     * Listeners must be registered here so that they are called for the proper events
+     * If a listener listens to multiple EventTypes it must be added for each EventType
+     */
+    @PostConstruct
+    public void registerListeners() {
+        EventListenerRegistry registry = ((SessionFactoryImpl) this.factory).getServiceRegistry().getService(EventListenerRegistry.class);
+        registry.getEventListenerGroup(EventType.PRE_INSERT).appendListener(monumentListener);
     }
 }

--- a/src/main/java/com/monumental/services/SessionFactoryService.java
+++ b/src/main/java/com/monumental/services/SessionFactoryService.java
@@ -1,9 +1,12 @@
 package com.monumental.services;
 
+import com.monumental.listeners.MonumentListener;
 import com.monumental.models.*;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
 import org.hibernate.service.ServiceRegistry;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +14,6 @@ import org.springframework.stereotype.Service;
 public class SessionFactoryService {
 
     private SessionFactory factory;
-    private ServiceRegistry registry;
 
     public SessionFactoryService() {
 
@@ -25,8 +27,10 @@ public class SessionFactoryService {
             for (Class c : classes) {
                 conf.addAnnotatedClass(c);
             }
-            this.registry = new StandardServiceRegistryBuilder().applySettings(conf.getProperties()).build();
-            this.factory = conf.buildSessionFactory(this.registry);
+            ServiceRegistry registry = new StandardServiceRegistryBuilder().applySettings(conf.getProperties()).build();
+            this.factory = conf.buildSessionFactory(registry);
+            EventListenerRegistry listenerRegistry = registry.getService(EventListenerRegistry.class);
+            listenerRegistry.getEventListenerGroup(EventType.PRE_INSERT).appendListener(new MonumentListener());
         } catch (Throwable ex) {
             System.err.println("Initial SessionFactory creation failed." + ex);
             throw new ExceptionInInitializerError(ex);


### PR DESCRIPTION
I've been looking into ways of generating slugs automatically

I work with Salesforce which makes heavy use of database triggers to change data or react to changes on insert/update/delete so that's where my head has immediately gone

Hibernate has these EventListeners such as `PreInsertEventListener` that are basically the same thing, except for some reason way more complex to setup and not-so-great feeling to use.

However, I've got basic slug stuff working with them and there's more left to do:
- [X] Before insert, generate slug
- [X] Before update, modify slug if the related fields (title, city, state) were changed
- [X] Ensure uniqueness by checking if the slug is already used and incrementing a number at the end
- [ ] If there are `slug` and `slug-1`, and `slug` get's deleted/changed, and another matching record is inserted, it becomes `slug-2` even though `slug` is available. Basically this means once a slug is used nothing else can ever take the slug, which is probably not desirable (if there's no `lincoln-memorial` then why should there be a `lincoln-memorial-1` for example)
- [ ] This definitely needs some unit tests
- [ ] Registering listeners is really janky, maybe there's a way to make it nicer
- [ ] Performance concerns - this is doing database queries on every insert/update, how bad does this affect performance when doing bulk inserts/updates