### PR TITLE
React SPA Setup

### DIFF
--- a/src/main/java/com/monumental/ReactRedirectFilter.java
+++ b/src/main/java/com/monumental/ReactRedirectFilter.java
@@ -1,0 +1,35 @@
+package com.monumental;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@Component
+public class ReactRedirectFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        String requestURI = req.getRequestURI();
+
+        // Any requests to the API should continue on as normal and reach their API Controller
+        if (requestURI.startsWith("/api")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // Assume that this always indicates a file request, which should proceed as normal
+        // In the future we may need to make this more intelligent or narrow
+        if (requestURI.contains(".")) {
+            System.out.println(requestURI);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // All requests that are not to the API or for static files will be redirected to the index page
+        // which will serve React and preserve the URL path, allowing React to see what page you were
+        // trying to access and update its state accordingly
+        request.getRequestDispatcher("/").forward(request, response);
+    }
+}

--- a/src/main/java/com/monumental/ReactRedirectFilter.java
+++ b/src/main/java/com/monumental/ReactRedirectFilter.java
@@ -22,7 +22,6 @@ public class ReactRedirectFilter implements Filter {
         // Assume that this always indicates a file request, which should proceed as normal
         // In the future we may need to make this more intelligent or narrow
         if (requestURI.contains(".")) {
-            System.out.println(requestURI);
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/monumental/controllers/api/MonumentController.java
+++ b/src/main/java/com/monumental/controllers/api/MonumentController.java
@@ -3,29 +3,21 @@ package com.monumental.controllers.api;
 import com.monumental.models.Monument;
 import com.monumental.services.MonumentService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
-
-@Controller
-public class MonumentApiController {
+@RestController
+public class MonumentController {
 
     @Autowired
     private MonumentService monumentService;
 
     @PostMapping("/api/monument")
-    @ResponseBody
     public Monument createMonument(Monument monument) {
         this.monumentService.insert(monument);
         return monument;
     }
 
     @GetMapping("/api/monument/{id}")
-    @ResponseBody
     public Monument getMonument(@PathVariable("id") Integer id) {
         return this.monumentService.get(id);
     }


### PR DESCRIPTION
This PR changes the server's URL routing so that:
1. All requests to `/api/` continue as normal to their controller
2. All requests to files continue as normal and are served from the `build/static` folder (currently this literally just checks if there's a `.` in the URI path, which may be insufficient)
3. All other requests serve React, and the path is preserved, which is important because it allows React to see that the URI is something other than `/` (such as `/monuments/1/lincoln-memorial`) and react (badum-ts) appropriately (such as display the monument record page)

I also renamed `MonumentAPIController` to `MonumentController` since all controllers will be `@RestController`s moving forward

This is a prerequisite for getting React routing working as well as working on slugs in monument urls