### PR TITLE
Change run script to use port 80

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo java -jar build/libs/monuments-and-memorials-0.0.1-SNAPSHOT.jar
+sudo java -jar build/libs/monuments-and-memorials-0.0.1-SNAPSHOT.jar --server.port=80


### PR DESCRIPTION
This script is used by the VM to start the server, so changing this makes the server run at `monumental.se.rit.edu` instead of `monumental.se.rit.edu:8080`