### PR TITLE
Monument -- Add groundwork for Image and Tag support

### DIFF
--- a/src/main/java/com/monumental/models/Image.java
+++ b/src/main/java/com/monumental/models/Image.java
@@ -1,0 +1,44 @@
+package com.monumental.models;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * Model class for an Image
+ * Contains all of the state related to an Image and Getters and Setters for that state
+ * Contains a many-to-one relationship with Monument
+ */
+
+@Entity
+@Table(name = "image", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "id")
+})
+public class Image extends Model implements Serializable {
+
+    @Column(name = "url")
+    private String url;
+
+    @ManyToOne
+    @JoinColumn(name = "monument_id", nullable = false)
+    private Monument monument;
+
+    public Image() {
+
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Monument getMonument() {
+        return this.monument;
+    }
+
+    public void setMonument(Monument monument) {
+        this.monument = monument;
+    }
+}

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -3,13 +3,13 @@ package com.monumental.models;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Set;
 
 /**
  * Model class for both Monuments and Memorials
  * The name Monument is chosen for simplicity as monuments and memorials have no difference within the system
  * Contains all of the state for a Monument as well as Setters and Getters for the state
- * TODO: Determine how to store "materials" (right now just a String but the spreadsheet is a bit more complex)
- * TODO: Setup FK relationship to Tags
+ * Contains a many-to-many relationship with Tag
  * TODO: Setup FK relationship to Images
  */
 
@@ -46,6 +46,17 @@ public class Monument extends Model implements Serializable {
 
     @Column(name = "state")
     private String state;
+
+    @ManyToMany(cascade = { CascadeType.ALL })
+    @JoinTable(
+            name = "monument_tag",
+            joinColumns = { @JoinColumn(name = "monument_id", referencedColumnName = "id") },
+            inverseJoinColumns = { @JoinColumn(name = "tag_id", referencedColumnName = "id") }
+    )
+    private Set<Tag> tags;
+
+    @OneToMany(mappedBy = "monument")
+    private Set<Image> images;
 
     public Monument() {
 
@@ -138,6 +149,14 @@ public class Monument extends Model implements Serializable {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public Set<Tag> getTags() {
+        return this.tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
     }
 
     public String toString() {

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -10,7 +10,6 @@ import java.util.Set;
  * The name Monument is chosen for simplicity as monuments and memorials have no difference within the system
  * Contains all of the state for a Monument as well as Setters and Getters for the state
  * Contains a many-to-many relationship with Tag
- * TODO: Setup FK relationship to Images
  */
 
 @Entity

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -161,6 +161,7 @@ public class Monument extends Model implements Serializable {
 
     public void setAddress(String address) {
         this.address = address;
+    }
 
     public Set<Tag> getTags() {
         return this.tags;

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -159,6 +159,14 @@ public class Monument extends Model implements Serializable {
         this.tags = tags;
     }
 
+    public Set<Image> getImages() {
+        return this.images;
+    }
+
+    public void setImages(Set<Image> images) {
+        this.images = images;
+    }
+
     public String toString() {
         return "Submitted by: " + this.submittedBy +  ", Artist: " + this.artist + ", Title: " + this.title + ", Date: "
                 + this.date + ", Material: " + this.material + ", Coordinates: " + this.getCoordinatePointAsString()

--- a/src/main/java/com/monumental/models/Tag.java
+++ b/src/main/java/com/monumental/models/Tag.java
@@ -1,0 +1,44 @@
+package com.monumental.models;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * Model class for a Tag
+ * Contains all of the state related to a Tag and Getters and Setters for that state
+ * Contains a many-to-many relationship with Monument
+ */
+
+@Entity
+@Table(name = "tag", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "id")
+})
+public class Tag extends Model implements Serializable {
+
+    @Column(name = "name")
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Monument> monuments;
+
+    public Tag() {
+
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Monument> getMonument() {
+        return this.monuments;
+    }
+
+    public void setMonuments(Set<Monument> monuments) {
+        this.monuments = monuments;
+    }
+}

--- a/src/main/java/com/monumental/services/SessionFactoryService.java
+++ b/src/main/java/com/monumental/services/SessionFactoryService.java
@@ -20,7 +20,9 @@ public class SessionFactoryService {
                     .configure();
             Class[] classes = new Class[]{
                     Model.class,
-                    Monument.class
+                    Monument.class,
+                    Tag.class,
+                    Image.class
             };
             for (Class c : classes) {
                 conf.addAnnotatedClass(c);

--- a/src/main/java/com/monumental/services/SessionFactoryService.java
+++ b/src/main/java/com/monumental/services/SessionFactoryService.java
@@ -1,7 +1,9 @@
 package com.monumental.services;
 
+import com.monumental.models.Image;
 import com.monumental.models.Model;
 import com.monumental.models.Monument;
+import com.monumental.models.Tag;
 import com.monumental.triggers.MonumentTrigger;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;


### PR DESCRIPTION
I added a Tag table and Image table that we can use in future work.

Tags and Monuments have a many-to-many relationship. At the database level, this is done via a join table with two columns: monument_id and tag_id. Both columns are foreign keys to the monument table and tag table respectively.

Images and Monuments have a many-to-one relationship. At the database level, this is just a join column in the images table that is a foreign key to the id column in the monument table.