### PR TITLE
Update view monument page to use the desired layout/styling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,4 +72,5 @@ task copyWebApp(type: Copy, dependsOn: [appNpmBuild]) {
     into 'build/resources/main/static/'
 }
 
-processResources.dependsOn 'copyWebApp'
+// Enable this to ALWAYS build react when building the Java app
+// processResources.dependsOn 'copyWebApp'

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7098,7 +7098,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7122,6 +7123,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7134,7 +7136,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7143,7 +7146,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7246,7 +7250,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7256,6 +7261,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7268,17 +7274,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7295,6 +7304,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7367,7 +7377,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7377,6 +7388,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7452,7 +7464,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7482,6 +7495,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7499,6 +7513,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7537,11 +7552,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -8662,6 +8679,11 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "react": "^16.9.0",
     "react-bootstrap": "^1.0.0-beta.14",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link href="https://fonts.googleapis.com/css?family=Open Sans:300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+          rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link href="https://fonts.googleapis.com/css?family=Open Sans:300,400,500,600,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open Sans:700|Roboto:300,400,500,700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
           rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link href="https://fonts.googleapis.com/css?family=Open Sans:300,400,500,600,700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,7 +13,7 @@ function App() {
                 <Header/>
                 <div className="page">
                     <Route path="/map">
-                        <div className="gmaps">
+                        <div className="homepage-map gmaps">
                             <div className="mapouter">
                                 <div className="gmap_canvas">
                                     <iframe id="gmap_canvas"

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -17,10 +17,10 @@ body {
 }
 
 .page {
-    padding: 0 1rem;
+    padding: 0 1rem 1rem 1rem;
 
     @include media-breakpoint-up(lg) {
-        padding: 0 2rem;
+        padding: 0 2rem 2rem 2rem;
     }
 }
 

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -20,7 +20,7 @@ body {
     padding: 0 1rem;
 
     @include media-breakpoint-up(lg) {
-        padding: 0 4rem;
+        padding: 0 2rem;
     }
 }
 

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1,5 +1,5 @@
 * {
-    font-family: "Open Sans", Arial, sans-serif;
+    font-family: Roboto, Arial, sans-serif;
 }
 
 .App {
@@ -25,9 +25,11 @@ body {
     background: none !important;
 }
 
-iframe, .mapouter, .gmap_canvas {
-    width: 80vw;
-    height: 80vh;
+homepage-map {
+    iframe, .mapouter, .gmap_canvas {
+        width: 80vw;
+        height: 80vh;
+    }
 }
 
 .gmaps {
@@ -37,4 +39,19 @@ iframe, .mapouter, .gmap_canvas {
 
 .card {
     box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px 0;
+}
+
+.card {
+    .card-title {
+        padding: 1.25rem;
+        font-weight: 500;
+    }
+}
+
+.tag {
+    background-color: #e8e8e8;
+    color: rgba(0, 0, 0, 0.8);
+    padding: .5em .75em;
+    border-radius: .28571429rem;
+    font-size: 0.8rem;
 }

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1,3 +1,8 @@
+@import "../node_modules/bootstrap/scss/functions";
+@import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/mixins";
+
+
 * {
     font-family: Roboto, Arial, sans-serif;
 }
@@ -12,7 +17,11 @@ body {
 }
 
 .page {
-    padding: 0 4rem;
+    padding: 0 1rem;
+
+    @include media-breakpoint-up(lg) {
+        padding: 0 4rem;
+    }
 }
 
 .mapouter {

--- a/client/src/components/Header/Header.scss
+++ b/client/src/components/Header/Header.scss
@@ -10,7 +10,7 @@
     }
 
     .left {
-        left: 5rem;
+        left: 2rem;
     }
 
     .right {

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -132,7 +132,9 @@ export default class Monument extends React.Component {
                                 </div>
                                 <div className="overlay">
                                     <div className="icon-wrapper">
-                                        <i className="far fa-eye"/>
+                                        <i className="material-icons">
+                                            open_in_new
+                                        </i>
                                     </div>
                                 </div>
                                 <div onClick={e => e.stopPropagation()}>
@@ -203,7 +205,7 @@ export default class Monument extends React.Component {
         if (monument.address) {
             return (
                 <div>
-                    <i className="fa fas fa-map-marker-alt text-primary"></i> {monument.address}
+                    <i className="material-icons">room</i> {monument.address}
                 </div>
             )
         } else return (<div/>);

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import './Monument.scss';
 import { Redirect } from 'react-router-dom';
-import { Card } from 'react-bootstrap';
+import { Button, Card, Collapse } from 'react-bootstrap';
 import * as slugify from 'slugify';
+import * as moment from 'moment';
 
 export default class Monument extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {monument: {}, monumentProperties: []};
+        this.state = {monument: {}, monumentProperties: [], detailsOpen: false};
     }
 
     async componentDidMount() {
@@ -16,12 +17,12 @@ export default class Monument extends React.Component {
         const response = await fetch(`/api/monument/${monumentId}`);
         const monument = await response.json();
         console.log(monument);
-        const monumentProperties = [];
-        for (let prop in monument) {
-            if (!monument.hasOwnProperty(prop)) continue;
-            monumentProperties.push({name: prop, value: monument[prop]});
+        if (monument.errors) {
+            console.error(monument.errors);
+            this.setState({error: monument.errors[0]});
+            return;
         }
-        this.setState({monument, monumentProperties, slug});
+        this.setState({monument, slug});
     }
 
     /**
@@ -43,26 +44,114 @@ export default class Monument extends React.Component {
     }
 
     render() {
+        if (this.state.error) return this.renderError();
+
+        return (
+            <div className="page-container container">
+                <div class="row">
+                    {this.redirectToSlug()}
+                    <div className="col"/>
+                    <div className="col d-flex justify-content-center">
+                        {this.renderMainCard()}
+                    </div>
+                    <div className="col d-flex justify-content-center">
+                        {this.renderVisitCard()}
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    renderMainCard() {
+        const monument = this.state.monument;
+
+        const capitalize = (word) => word ? word.charAt(0).toUpperCase() + word.slice(1).trim() : word;
+        const parseState = (state) => {
+            if (!state) return state;
+            if (state.toLowerCase() === 'dc') state = 'd.c.';
+            return state.toUpperCase().trim();
+        };
+        const prettyPrintDate = (date) => {
+            if (!date) return;
+            date = moment(new Date(date));
+            // Wednesday, October 16th, 2019 format
+            return date.format('dddd, MMMM Do, YYYY');
+        };
+
+        return (
+            <div className="main">
+                <Card>
+                    <Card.Title>
+                        {monument.title}
+                    </Card.Title>
+                    <Card.Body>
+                        <div className="fields">
+                            <div className="field font-italic">{capitalize(monument.city)}, {parseState(monument.state)}</div>
+                            <div className="field">{monument.title} is a {monument.material} monument{monument.date ? ' dedicated on ' + prettyPrintDate(monument.date) : ''}.</div>
+                        </div>
+                        <span className="tag">{monument.material}</span>
+                        <div className="details">
+                            <Button variant="link" onClick={() => this.setState({open: !this.state.open})}>
+                                {this.state.open ? 'Hide details' : 'More details'}
+                            </Button>
+                            <Collapse in={this.state.open}>
+                                <div>
+                                    <div>
+                                        <span className="detail-label">Contributors:&nbsp;</span>
+                                        {monument.submittedBy}
+                                    </div>
+                                    <div>
+                                        <span className="detail-label">Last Updated:&nbsp;</span>
+                                        {prettyPrintDate(monument.updatedDate)}
+                                    </div>
+                                </div>
+                            </Collapse>
+                        </div>
+                    </Card.Body>
+                </Card>
+            </div>
+        )
+    }
+
+    renderVisitCard() {
+        const monument = this.state.monument;
+
+        return (
+            <div className="visit">
+                <Card>
+                    <Card.Title>
+                        Visit
+                    </Card.Title>
+                    <Card.Body>
+                        {this.renderAddress()}
+                        <div className="map">
+                            <iframe title="gmaps-iframe"
+                                    src={`https://maps.google.com/maps?q=${monument.address ? monument.address : monument.coordinatePointAsString}&z=16&output=embed`}
+                                    frameBorder="0"/>
+                        </div>
+                    </Card.Body>
+                </Card>
+            </div>
+        )
+    }
+
+    renderAddress() {
+        const monument = this.state.monument;
+        if (monument.address) {
+            return (
+                <div>
+                    <i className="fa fas fa-map-marker-alt text-primary"></i> {monument.address}
+                </div>
+            )
+        } else return (<div/>);
+    }
+
+    // TODO: Make this pretty
+    renderError() {
+        const error = this.state.error;
         return (
             <div className="page-container">
-                {this.redirectToSlug()}
-                <div className="fields">
-                    <Card>
-                        <Card.Body>
-                            {this.state.monumentProperties.map(prop =>
-                                <div key={prop.name}>
-                                    <span style={{fontWeight: 'bold'}}>{prop.name}:&nbsp;</span>
-                                    <span>{prop.value}</span>
-                                </div>
-                            )}
-                        </Card.Body>
-                    </Card>
-                </div>
-                <div className="map">
-                    <iframe title="gmaps-iframe"
-                            src={`https://maps.google.com/maps?q=${this.state.monument.coordinatePointAsString}&z=16&output=embed`}
-                            frameBorder="0"/>
-                </div>
+                <span>An error occurred: "{error.message}"</span>
             </div>
         )
     }

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -166,7 +166,7 @@ export default class Monument extends React.Component {
                                     <div>
                                         <span className="detail-label">References:&nbsp;</span>
                                         <ul>
-                                            {references.map(reference => <li key={reference.url}><a href={reference.url}>{reference.url}</a></li>)}
+                                            {references.map(reference => <li key={reference.url}><a className="text-break" href={reference.url}>{reference.url}</a></li>)}
                                         </ul>
                                     </div>
                                 </div>

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -154,19 +154,19 @@ export default class Monument extends React.Component {
                             <Collapse in={this.state.detailsOpen}>
                                 <div>
                                     <div>
+                                        <span className="detail-label">Last Updated:&nbsp;</span>
+                                        {prettyPrintDate(monument.updatedDate)}
+                                    </div>
+                                    <div>
                                         <span className="detail-label">Contributors:&nbsp;</span>
                                         <ul>
                                             {contributions.map(contribution => <li key={contribution.submittedBy}>{contribution.submittedBy}</li>)}
                                         </ul>
                                     </div>
                                     <div>
-                                        <span className="detail-label">Last Updated:&nbsp;</span>
-                                        {prettyPrintDate(monument.updatedDate)}
-                                    </div>
-                                    <div>
                                         <span className="detail-label">References:&nbsp;</span>
                                         <ul>
-                                            {references.map(reference => <li key={reference.url}>{reference.url}</li>)}
+                                            {references.map(reference => <li key={reference.url}><a href={reference.url}>{reference.url}</a></li>)}
                                         </ul>
                                     </div>
                                 </div>

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -152,7 +152,7 @@ export default class Monument extends React.Component {
                                 {this.state.detailsOpen ? 'Hide details' : 'More details'}
                             </Button>
                             <Collapse in={this.state.detailsOpen}>
-                                <div>
+                                <div className="detail-list">
                                     <div>
                                         <span className="detail-label">Last Updated:&nbsp;</span>
                                         {prettyPrintDate(monument.updatedDate)}

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -1,10 +1,45 @@
+@import "../../../node_modules/bootstrap/scss/functions";
+@import "../../../node_modules/bootstrap/scss/variables";
+@import "../../../node_modules/bootstrap/scss/mixins";
+
 .page-container {
     min-width: 100%;
     margin: 0;
+    display: flex;
+    flex-direction: column;
+
+    .column {
+        flex: 1 1 100%;
+        padding: 1rem 0;
+        &.main-column {
+            padding-top: 0;
+        }
+        &.related-monuments-column {
+            order: 3;
+            padding-bottom: 0;
+        }
+    }
+
+    @include media-breakpoint-up(lg) {
+        flex-direction: row;
+        .column {
+            flex-basis: 30%;
+            padding: 0 1rem;
+            &.related-monuments-column {
+                order: unset;
+                padding-left: 0;
+            }
+            &.main-column {
+                flex-basis: 40%;
+            }
+            &.visit-column {
+                padding-right: 0;
+            }
+        }
+    }
 }
 
 .main {
-    min-width: 300px;
 
     .fields .field {
         margin-bottom: 1rem;
@@ -42,8 +77,7 @@
     }
 
     iframe, .mapouter, .gmap_canvas {
-
-        min-width: 500px;
-        min-height: 300px;
+        width: 100%;
+        min-height: 400px;
     }
 }

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -57,6 +57,7 @@
         margin: 1rem 0;
         background-color: rgb(30,30,30);
         position: relative;
+        cursor: pointer;
 
         .image-wrapper {
             display: flex;

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -1,17 +1,49 @@
 .page-container {
-    display: flex;
+    min-width: 100%;
+    margin: 0;
+}
 
-    .fields {
-        flex: 50%;
-        padding-right: 2em;
+.main {
+    min-width: 300px;
+
+    .fields .field {
+        margin-bottom: 1rem;
     }
 
-    .map {
-        flex: 100%;
-
-        iframe {
-            width: 100%;
-            max-width: 100%;
+    .details {
+        padding-top: 1rem;
+        .btn-link {
+            margin: 0;
+            padding: 0;
         }
+        .detail-label {
+            font-weight: 500;
+        }
+    }
+
+}
+
+.visit, .main {
+
+    .card-title {
+        margin-bottom: 0;
+        padding-bottom: 0.5rem;
+    }
+
+    .card-body {
+        margin-top: 0;
+        padding-top: 0;
+    }
+}
+
+.visit {
+    .card-title {
+        padding-bottom: 1rem;
+    }
+
+    iframe, .mapouter, .gmap_canvas {
+
+        min-width: 500px;
+        min-height: 300px;
     }
 }

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -112,6 +112,14 @@
         .detail-label {
             font-weight: 500;
         }
+        .detail-list {
+            ul, ol {
+                margin-bottom: 0;
+            }
+        }
+        .detail-list > div {
+            margin-bottom: 0.25rem;
+        }
     }
 }
 

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -23,14 +23,12 @@
     @include media-breakpoint-up(lg) {
         flex-direction: row;
         .column {
-            flex-basis: 30%;
+            flex-basis: 40%;
             padding: 0 1rem;
             &.related-monuments-column {
                 order: unset;
                 padding-left: 0;
-            }
-            &.main-column {
-                flex-basis: 40%;
+                flex-basis: 20%;
             }
             &.visit-column {
                 padding-right: 0;
@@ -64,16 +62,17 @@
             justify-content: center;
         }
 
-        img {
-            height: 300px;
+        img, .overlay {
+            max-height: 300px;
             width: auto;
+            max-width: 100%;
         }
 
         .overlay {
             position: absolute;
-            height: 300px;
             background-color: rgba(0,0,0,0);
             width: 100%;
+            height: 100%;
             top: 0;
             transition: background-color 0.1s ease-out;
 

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -45,6 +45,63 @@
         margin-bottom: 1rem;
     }
 
+    .tags .tag {
+        margin-right: 0.75rem;
+
+        &:last-child {
+            margin-right: 0;
+        }
+    }
+
+    .image-container {
+        margin: 1rem 0;
+        background-color: rgb(30,30,30);
+        position: relative;
+
+        .image-wrapper {
+            display: flex;
+            justify-content: center;
+        }
+
+        img {
+            height: 300px;
+            width: auto;
+        }
+
+        .overlay {
+            position: absolute;
+            height: 300px;
+            background-color: rgba(0,0,0,0);
+            width: 100%;
+            top: 0;
+            transition: background-color 0.1s ease-out;
+
+            .icon-wrapper {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 100%;
+                height: 100%;
+                opacity: 0;
+                transition: opacity 0.1s ease-out;
+            }
+
+            i {
+                color: white;
+                font-size: 2rem;
+            }
+        }
+
+        &:hover {
+            .overlay {
+                background-color: rgba(0,0,0,0.5);
+            }
+            .icon-wrapper {
+                opacity: 1;
+            }
+        }
+    }
+
     .details {
         padding-top: 1rem;
         .btn-link {
@@ -55,7 +112,12 @@
             font-weight: 500;
         }
     }
+}
 
+.modal-body {
+    img {
+        max-width: 100%;
+    }
 }
 
 .visit, .main {

--- a/src/main/java/com/monumental/controllers/ContributionController.java
+++ b/src/main/java/com/monumental/controllers/ContributionController.java
@@ -1,0 +1,22 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Contribution;
+import com.monumental.services.ContributionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ContributionController {
+
+    @Autowired
+    ContributionService contributionService;
+
+    @GetMapping("/api/contributions")
+    public List<Contribution> getContributions(@RequestParam Integer monumentId) {
+        return this.contributionService.getByMonumentId(monumentId);
+    }
+}

--- a/src/main/java/com/monumental/controllers/ImageController.java
+++ b/src/main/java/com/monumental/controllers/ImageController.java
@@ -1,0 +1,22 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Image;
+import com.monumental.services.ImageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ImageController {
+
+    @Autowired
+    ImageService imageService;
+
+    @GetMapping("/api/images")
+    public List<Image> getImages(@RequestParam Integer monumentId) {
+        return this.imageService.getByMonumentId(monumentId);
+    }
+}

--- a/src/main/java/com/monumental/controllers/ReferenceController.java
+++ b/src/main/java/com/monumental/controllers/ReferenceController.java
@@ -16,7 +16,7 @@ public class ReferenceController {
     ReferenceService referenceService;
 
     @GetMapping("/api/references")
-    public List<Reference> getImages(@RequestParam Integer monumentId) {
+    public List<Reference> getReferences(@RequestParam Integer monumentId) {
         return this.referenceService.getByMonumentId(monumentId);
     }
 }

--- a/src/main/java/com/monumental/controllers/ReferenceController.java
+++ b/src/main/java/com/monumental/controllers/ReferenceController.java
@@ -1,0 +1,22 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Reference;
+import com.monumental.services.ReferenceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ReferenceController {
+
+    @Autowired
+    ReferenceService referenceService;
+
+    @GetMapping("/api/references")
+    public List<Reference> getImages(@RequestParam Integer monumentId) {
+        return this.referenceService.getByMonumentId(monumentId);
+    }
+}

--- a/src/main/java/com/monumental/controllers/TagController.java
+++ b/src/main/java/com/monumental/controllers/TagController.java
@@ -16,7 +16,7 @@ public class TagController {
     TagService tagService;
 
     @GetMapping("/api/tags")
-    public List<Tag> getContributions(@RequestParam Integer monumentId) {
+    public List<Tag> getTags(@RequestParam Integer monumentId) {
         return this.tagService.getByMonumentId(monumentId);
     }
 }

--- a/src/main/java/com/monumental/controllers/TagController.java
+++ b/src/main/java/com/monumental/controllers/TagController.java
@@ -1,0 +1,22 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Tag;
+import com.monumental.services.TagService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class TagController {
+
+    @Autowired
+    TagService tagService;
+
+    @GetMapping("/api/tags")
+    public List<Tag> getContributions(@RequestParam Integer monumentId) {
+        return this.tagService.getByMonumentId(monumentId);
+    }
+}

--- a/src/main/java/com/monumental/models/Contribution.java
+++ b/src/main/java/com/monumental/models/Contribution.java
@@ -1,5 +1,7 @@
 package com.monumental.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -22,6 +24,7 @@ public class Contribution extends Model implements Serializable {
     @Column(name = "date")
     private Date date;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "monument_id", nullable = false)
     private Monument monument;

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -142,7 +142,7 @@ public class Monument extends Model implements Serializable {
 
     public String getCoordinatePointAsString() {
         if (this.lat == null || this.lon == null ) return "";
-        return Double.toString(this.lat) + ", " + Double.toString(this.lon);
+        return Double.toString(this.lon) + ", " + Double.toString(this.lat);
     }
 
     public String getCity() {

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -1,5 +1,7 @@
 package com.monumental.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -49,6 +51,7 @@ public class Monument extends Model implements Serializable {
     @Column(name = "address")
     private String address;
 
+    @JsonIgnore
     @ManyToMany(cascade = { CascadeType.ALL })
     @JoinTable(
             name = "monument_tag",
@@ -57,6 +60,7 @@ public class Monument extends Model implements Serializable {
     )
     private Set<Tag> tags;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "monument")
     private Set<Image> images;
 

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -1,6 +1,7 @@
 package com.monumental.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.LazyInitializationException;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -47,6 +48,7 @@ public class Monument extends Model implements Serializable {
   
     @Column(name = "address")
     private String address;
+
     @Column(name = "description")
     private String description;
 
@@ -62,16 +64,17 @@ public class Monument extends Model implements Serializable {
     )
     private List<Tag> tags;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "monument")
     private List<Image> images;
 
     @JsonIgnore
     @OneToMany(mappedBy = "monument")
-    private List<Contribution> contributions;
+    private List<Reference> references;
 
     @JsonIgnore
     @OneToMany(mappedBy = "monument")
-    private List<Reference> references;
+    private List<Contribution> contributions;
 
     public Monument() {
 
@@ -240,12 +243,16 @@ public class Monument extends Model implements Serializable {
 
         description += simpleDateFormat.format(this.date) + ".";
 
-        if (this.references != null) {
-            Reference firstReference = this.references.get(0);
+        try {
+            if (this.references != null) {
+                Reference firstReference = this.references.get(0);
 
-            if (firstReference != null && firstReference.getUrl() != null) {
-                description += " You may find further information about this monument at: " + firstReference.getUrl();
+                if (firstReference != null && firstReference.getUrl() != null) {
+                    description += " You may find further information about this monument at: " + firstReference.getUrl();
+                }
             }
+        } catch (LazyInitializationException e) {
+            // TODO: Initialize References before reaching this point
         }
 
         return description;

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -137,7 +137,7 @@ public class Monument extends Model implements Serializable {
 
     public String getCoordinatePointAsString() {
         if (this.lat == null || this.lon == null ) return "";
-        return Double.toString(this.lon) + ", " + Double.toString(this.lat);
+        return Double.toString(this.lat) + ", " + Double.toString(this.lon);
     }
 
     public String getCity() {

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -56,12 +56,7 @@ public class Monument extends Model implements Serializable {
     private String inscription;
 
     @JsonIgnore
-    @ManyToMany(cascade = { CascadeType.ALL })
-    @JoinTable(
-            name = "monument_tag",
-            joinColumns = { @JoinColumn(name = "monument_id", referencedColumnName = "id") },
-            inverseJoinColumns = { @JoinColumn(name = "tag_id", referencedColumnName = "id") }
-    )
+    @ManyToMany(mappedBy = "monuments")
     private List<Tag> tags;
 
     @JsonIgnore
@@ -237,14 +232,20 @@ public class Monument extends Model implements Serializable {
             description += "The ";
         }
 
-        description += this.title + " in " + this.city + ", " + this.state + " was created by " + this.artist + " in ";
+        description += this.title + " in " + this.city + ", " + this.state + " was created by " + this.artist;
 
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy");
+        if (this.date != null) {
+            description += " in ";
 
-        description += simpleDateFormat.format(this.date) + ".";
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy");
+
+            description += simpleDateFormat.format(this.date);
+        }
+
+        description += ".";
 
         try {
-            if (this.references != null) {
+            if (this.references != null && this.references.size() > 0) {
                 Reference firstReference = this.references.get(0);
 
                 if (firstReference != null && firstReference.getUrl() != null) {

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -69,6 +69,7 @@ public class Monument extends Model implements Serializable {
     @OneToMany(mappedBy = "monument")
     private List<Contribution> contributions;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "monument")
     private List<Reference> references;
 

--- a/src/main/java/com/monumental/models/Tag.java
+++ b/src/main/java/com/monumental/models/Tag.java
@@ -1,5 +1,7 @@
 package com.monumental.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Set;
@@ -19,6 +21,7 @@ public class Tag extends Model implements Serializable {
     @Column(name = "name")
     private String name;
 
+    @JsonIgnore
     @ManyToMany(mappedBy = "tags")
     private Set<Monument> monuments;
 
@@ -34,7 +37,7 @@ public class Tag extends Model implements Serializable {
         this.name = name;
     }
 
-    public Set<Monument> getMonument() {
+    public Set<Monument> getMonuments() {
         return this.monuments;
     }
 

--- a/src/main/java/com/monumental/models/Tag.java
+++ b/src/main/java/com/monumental/models/Tag.java
@@ -22,7 +22,12 @@ public class Tag extends Model implements Serializable {
     private String name;
 
     @JsonIgnore
-    @ManyToMany(mappedBy = "tags")
+    @ManyToMany(cascade = { CascadeType.ALL })
+    @JoinTable(
+            name = "monument_tag",
+            joinColumns = { @JoinColumn(name = "tag_id", referencedColumnName = "id") },
+            inverseJoinColumns = { @JoinColumn(name = "monument_id", referencedColumnName = "id") }
+    )
     private Set<Monument> monuments;
 
     public Tag() {

--- a/src/main/java/com/monumental/services/ContributionService.java
+++ b/src/main/java/com/monumental/services/ContributionService.java
@@ -1,0 +1,40 @@
+package com.monumental.services;
+
+import com.monumental.models.Contribution;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ContributionService extends ModelService<Contribution> {
+
+    @SuppressWarnings("unchecked")
+    public List<Contribution> getByMonumentId(Integer monumentId) {
+
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<Contribution> contributions;
+
+        try {
+            transaction = session.beginTransaction();
+            contributions = session.createQuery("FROM Contribution where monument_id = :monumentId")
+                    .setParameter("monumentId", monumentId)
+                    .list();
+            transaction.commit();
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            System.err.println("Error attempting to get all Contributions for Monument: " + monumentId);
+            System.err.println(e.getMessage());
+            throw e;
+        }
+
+        return contributions;
+    }
+}

--- a/src/main/java/com/monumental/services/ContributionService.java
+++ b/src/main/java/com/monumental/services/ContributionService.java
@@ -9,6 +9,10 @@ import java.util.List;
 public class ContributionService extends ModelService<Contribution> {
 
     public List<Contribution> getByMonumentId(Integer monumentId) {
-        return this.getByForeignKey("monument_id", monumentId);
+        return this.getByMonumentId(monumentId, false);
+    }
+
+    public List<Contribution> getByMonumentId(Integer monumentId, boolean initializeLazyLoadedCollections) {
+        return this.getByForeignKey("monument_id", monumentId, initializeLazyLoadedCollections);
     }
 }

--- a/src/main/java/com/monumental/services/ContributionService.java
+++ b/src/main/java/com/monumental/services/ContributionService.java
@@ -1,9 +1,6 @@
 package com.monumental.services;
 
 import com.monumental.models.Contribution;
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,30 +8,7 @@ import java.util.List;
 @Service
 public class ContributionService extends ModelService<Contribution> {
 
-    @SuppressWarnings("unchecked")
     public List<Contribution> getByMonumentId(Integer monumentId) {
-
-        Session session = this.sessionFactoryService.getFactory().openSession();
-        Transaction transaction = null;
-        List<Contribution> contributions;
-
-        try {
-            transaction = session.beginTransaction();
-            contributions = session.createQuery("FROM Contribution where monument_id = :monumentId")
-                    .setParameter("monumentId", monumentId)
-                    .list();
-            transaction.commit();
-            session.close();
-        } catch (HibernateException e) {
-            if (transaction != null) {
-                transaction.rollback();
-            }
-            session.close();
-            System.err.println("Error attempting to get all Contributions for Monument: " + monumentId);
-            System.err.println(e.getMessage());
-            throw e;
-        }
-
-        return contributions;
+        return this.getByForeignKey("monument_id", monumentId);
     }
 }

--- a/src/main/java/com/monumental/services/ImageService.java
+++ b/src/main/java/com/monumental/services/ImageService.java
@@ -1,0 +1,40 @@
+package com.monumental.services;
+
+import com.monumental.models.Image;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ImageService extends ModelService<Image> {
+
+    @SuppressWarnings("unchecked")
+    public List<Image> getByMonumentId(Integer monumentId) {
+
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<Image> images;
+
+        try {
+            transaction = session.beginTransaction();
+            images = session.createQuery("FROM Image where monument_id = :monumentId")
+                    .setParameter("monumentId", monumentId)
+                    .list();
+            transaction.commit();
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            System.err.println("Error attempting to get all Images for Monument: " + monumentId);
+            System.err.println(e.getMessage());
+            throw e;
+        }
+
+        return images;
+    }
+}

--- a/src/main/java/com/monumental/services/ImageService.java
+++ b/src/main/java/com/monumental/services/ImageService.java
@@ -9,6 +9,10 @@ import java.util.List;
 public class ImageService extends ModelService<Image> {
 
     public List<Image> getByMonumentId(Integer monumentId) {
-        return this.getByForeignKey("monument_id", monumentId);
+        return this.getByMonumentId(monumentId, false);
+    }
+
+    public List<Image> getByMonumentId(Integer monumentId, boolean initializeLazyLoadedCollections) {
+        return this.getByForeignKey("monument_id", monumentId, initializeLazyLoadedCollections);
     }
 }

--- a/src/main/java/com/monumental/services/ModelService.java
+++ b/src/main/java/com/monumental/services/ModelService.java
@@ -190,4 +190,31 @@ public abstract class ModelService<T extends Model> {
     public void delete(List<Integer> ids) throws HibernateException {
         this.doDelete(ids);
     }
+
+    @SuppressWarnings("unchecked")
+    List<T> getByForeignKey(String foreignKeyName, Integer foreignKey) {
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<T> records;
+        String tableName = this.getModelClass().getName();
+
+        try {
+            transaction = session.beginTransaction();
+            records = session.createQuery("FROM " + tableName + " where " + foreignKeyName + " = :foreignKey")
+                    .setParameter("foreignKey", foreignKey)
+                    .list();
+            transaction.commit();
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            System.err.println("Error attempting to get " + tableName + " by foreign key " + foreignKeyName + ": " + foreignKey);
+            System.err.println(e.getMessage());
+            throw e;
+        }
+
+        return records;
+    }
 }

--- a/src/main/java/com/monumental/services/ModelService.java
+++ b/src/main/java/com/monumental/services/ModelService.java
@@ -281,6 +281,12 @@ public abstract class ModelService<T extends Model> {
         return records;
     }
 
+    /**
+     * Helper method that attempts to get and initialize all collections on a record before its session is closed
+     * This is helpful when you need to access lazy loaded data, since sessions are always closed in the get methods
+     * before the calling class ever has a chance to initialize lazy collections
+     * Modified from this answer https://stackoverflow.com/a/24870618/10044594
+     */
     private void initializeLazyLoadedCollections(List<T> records) {
         for (T record : records) {
             Method[] methods = record.getClass().getMethods();

--- a/src/main/java/com/monumental/services/ReferenceService.java
+++ b/src/main/java/com/monumental/services/ReferenceService.java
@@ -1,14 +1,14 @@
 package com.monumental.services;
 
-import com.monumental.models.Image;
+import com.monumental.models.Reference;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class ImageService extends ModelService<Image> {
+public class ReferenceService extends ModelService<Reference> {
 
-    public List<Image> getByMonumentId(Integer monumentId) {
+    public List<Reference> getByMonumentId(Integer monumentId) {
         return this.getByForeignKey("monument_id", monumentId);
     }
 }

--- a/src/main/java/com/monumental/services/ReferenceService.java
+++ b/src/main/java/com/monumental/services/ReferenceService.java
@@ -9,6 +9,10 @@ import java.util.List;
 public class ReferenceService extends ModelService<Reference> {
 
     public List<Reference> getByMonumentId(Integer monumentId) {
-        return this.getByForeignKey("monument_id", monumentId);
+        return this.getByMonumentId(monumentId, false);
+    }
+
+    public List<Reference> getByMonumentId(Integer monumentId, boolean initializeLazyLoadedCollections) {
+        return this.getByForeignKey("monument_id", monumentId, initializeLazyLoadedCollections);
     }
 }

--- a/src/main/java/com/monumental/services/TagService.java
+++ b/src/main/java/com/monumental/services/TagService.java
@@ -1,0 +1,40 @@
+package com.monumental.services;
+
+import com.monumental.models.Tag;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TagService extends ModelService<Tag> {
+
+    @SuppressWarnings("unchecked")
+    public List<Tag> getByMonumentId(Integer monumentId) {
+
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<Tag> tags;
+
+        try {
+            transaction = session.beginTransaction();
+            tags = session.createQuery("FROM Tag where monument_id = :monumentId")
+                    .setParameter("monumentId", monumentId)
+                    .list();
+            transaction.commit();
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            System.err.println("Error attempting to get all Tags for Monument: " + monumentId);
+            System.err.println(e.getMessage());
+            throw e;
+        }
+
+        return tags;
+    }
+}

--- a/src/main/java/com/monumental/services/TagService.java
+++ b/src/main/java/com/monumental/services/TagService.java
@@ -9,6 +9,10 @@ import java.util.List;
 public class TagService extends ModelService<Tag> {
 
     public List<Tag> getByMonumentId(Integer monumentId) {
-        return this.getByJoinTable("monuments", "id", monumentId);
+        return this.getByMonumentId(monumentId, false);
+    }
+
+    public List<Tag> getByMonumentId(Integer monumentId, boolean initializeLazyLoadedCollections) {
+        return this.getByJoinTable("monuments", "id", monumentId, initializeLazyLoadedCollections);
     }
 }

--- a/src/main/java/com/monumental/services/TagService.java
+++ b/src/main/java/com/monumental/services/TagService.java
@@ -8,8 +8,7 @@ import java.util.List;
 @Service
 public class TagService extends ModelService<Tag> {
 
-    // TODO: This doesn't work, it needs to use the junction table
     public List<Tag> getByMonumentId(Integer monumentId) {
-        return this.getByForeignKey("monument_id", monumentId);
+        return this.getByJoinTable("monuments", "id", monumentId);
     }
 }

--- a/src/main/java/com/monumental/services/TagService.java
+++ b/src/main/java/com/monumental/services/TagService.java
@@ -1,9 +1,6 @@
 package com.monumental.services;
 
 import com.monumental.models.Tag;
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,30 +8,8 @@ import java.util.List;
 @Service
 public class TagService extends ModelService<Tag> {
 
-    @SuppressWarnings("unchecked")
+    // TODO: This doesn't work, it needs to use the junction table
     public List<Tag> getByMonumentId(Integer monumentId) {
-
-        Session session = this.sessionFactoryService.getFactory().openSession();
-        Transaction transaction = null;
-        List<Tag> tags;
-
-        try {
-            transaction = session.beginTransaction();
-            tags = session.createQuery("FROM Tag where monument_id = :monumentId")
-                    .setParameter("monumentId", monumentId)
-                    .list();
-            transaction.commit();
-            session.close();
-        } catch (HibernateException e) {
-            if (transaction != null) {
-                transaction.rollback();
-            }
-            session.close();
-            System.err.println("Error attempting to get all Tags for Monument: " + monumentId);
-            System.err.println(e.getMessage());
-            throw e;
-        }
-
-        return tags;
+        return this.getByForeignKey("monument_id", monumentId);
     }
 }

--- a/src/test/java/com/monumental/services/integrationtest/ImageServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/ImageServiceIntegrationTests.java
@@ -1,0 +1,82 @@
+package com.monumental.services.integrationtest;
+
+
+import com.monumental.models.Image;
+import com.monumental.models.Monument;
+import com.monumental.services.ImageService;
+import com.monumental.services.MonumentService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ImageServiceIntegrationTests {
+
+    @Autowired
+    private ImageService imageService;
+
+    @Autowired
+    private MonumentService monumentService;
+
+    /**
+     * Tests ImageService's getByMonumentId and the underlying ModelService's getByForeignKey
+     */
+    @Test
+    public void testImageService_GetByMonumentId() {
+        List<Integer> monumentIds = setupMonumentsAndImages();
+        assertEquals(2, monumentIds.size());
+
+        List<Image> firstImages = imageService.getByMonumentId(monumentIds.get(0));
+        assertEquals(2, firstImages.size());
+        for (Image image : firstImages) {
+            assert(Arrays.asList("url1", "url2").contains(image.getUrl()));
+            assertEquals(monumentIds.get(0), image.getMonument().getId());
+        }
+
+        List<Image> secondImages = imageService.getByMonumentId(monumentIds.get(1));
+        assertEquals(1, secondImages.size());
+        assertEquals("url3", secondImages.get(0).getUrl());
+        assertEquals(monumentIds.get(1), secondImages.get(0).getMonument().getId());
+    }
+
+    /**
+     * Helper that sets up 2 Monuments and 3 Images, with 2 Images related to the same Monument
+     */
+    private List<Integer> setupMonumentsAndImages() {
+        Monument monument1 = new Monument();
+        monument1.setTitle("Monument 1");
+        monument1.setArtist("Artist 1");
+
+        Monument monument2 = new Monument();
+        monument2.setTitle("Monument 2");
+        monument2.setArtist("Artist 2");
+
+        List<Integer> monumentIds = monumentService.insert(Arrays.asList(monument1, monument2));
+
+        Image image1 = new Image();
+        image1.setMonument(monument1);
+        image1.setUrl("url1");
+
+        Image image2 = new Image();
+        image2.setMonument(monument1);
+        image2.setUrl("url2");
+
+        Image image3 = new Image();
+        image3.setMonument(monument2);
+        image3.setUrl("url3");
+
+        imageService.insert(Arrays.asList(image1, image2, image3));
+
+        return monumentIds;
+    }
+}

--- a/src/test/java/com/monumental/services/integrationtest/TagServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/TagServiceIntegrationTests.java
@@ -1,0 +1,96 @@
+package com.monumental.services.integrationtest;
+
+import com.monumental.models.Monument;
+import com.monumental.models.Tag;
+import com.monumental.services.MonumentService;
+import com.monumental.services.TagService;
+import org.hibernate.Hibernate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class TagServiceIntegrationTests {
+
+    @Autowired
+    private TagService tagService;
+
+    @Autowired
+    private MonumentService monumentService;
+
+
+    /**
+     * Tests ImageService's getByMonumentId and the underlying ModelService's getByJoinTable
+     */
+    @Test
+    public void testTagService_GetByMonumentId() {
+        List<Integer> monumentIds = setupMonumentsAndTags();
+        assertEquals(2, monumentIds.size());
+
+        List<Tag> firstTags = tagService.getByMonumentId(monumentIds.get(0), true);
+        assertEquals(2, firstTags.size());
+        for (Tag tag : firstTags) {
+            assert(Arrays.asList("tag1", "tag2").contains(tag.getName()));
+            boolean hasMonument = false;
+            for (Monument monument : tag.getMonuments()) {
+                if (monument.getId().equals(monumentIds.get(0))) {
+                    hasMonument = true;
+                    break;
+                }
+            }
+            assert(hasMonument);
+        }
+
+        List<Tag> secondTags = tagService.getByMonumentId(monumentIds.get(1), true);
+        assertEquals(1, secondTags.size());
+        assertEquals("tag2", secondTags.get(0).getName());
+        boolean hasMonument = false;
+        for (Monument monument : secondTags.get(0).getMonuments()) {
+            if (monument.getId().equals(monumentIds.get(1))) {
+                hasMonument = true;
+                break;
+            }
+        }
+        assert(hasMonument);
+    }
+
+    /**
+     * Helper that sets up 2 Monuments and 2 Tags, with 1 Tags related to both Monuments
+     */
+    private List<Integer> setupMonumentsAndTags() {
+        Monument monument1 = new Monument();
+        monument1.setTitle("Monument 1");
+        monument1.setArtist("Artist 1");
+
+        Monument monument2 = new Monument();
+        monument2.setTitle("Monument 2");
+        monument2.setArtist("Artist 2");
+
+        List<Integer> monumentIds = monumentService.insert(Arrays.asList(monument1, monument2));
+        monument1.setId(monumentIds.get(0));
+        monument2.setId(monumentIds.get(1));
+
+        Tag tag1 = new Tag();
+        tag1.setMonuments(new HashSet<>(Arrays.asList(monument1)));
+        tag1.setName("tag1");
+
+        Tag tag2 = new Tag();
+        tag2.setMonuments(new HashSet<>(Arrays.asList(monument1, monument2)));
+        tag2.setName("tag2");
+
+        tagService.insert(Arrays.asList(tag1, tag2));
+
+        return monumentIds;
+    }
+}


### PR DESCRIPTION
This is a first pass at making the view monument page look like what we decided on. There is still tweaking to do, both with content and styling.

1. I'm definitely forgetting some fields to put in the more details section
2. There's no images, tags (besides material), or contributors (besides submitter)
3. The three column layout is not done very well (map never resizes automatically currently, needs to `flex-grow`)

Anyway here's what it looks like (the `Less details` link works, it collapses/shows and on page load is collapsed)
![image](https://user-images.githubusercontent.com/25756457/66914904-c8632200-efe5-11e9-9eed-c72ca53dd03d.png)
