### PR TITLE
Add basic monument title search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,5 @@
 # Custom db runner script
 run_db.cmd
 
-# Hibernate configuration
-*/hibernate.cfg.xml
-
 # Travis
 .travis/id_rsa

--- a/src/main/java/com/monumental/CustomPostgreSQL9Dialect.java
+++ b/src/main/java/com/monumental/CustomPostgreSQL9Dialect.java
@@ -1,0 +1,14 @@
+package com.monumental;
+
+import org.hibernate.dialect.PostgreSQL9Dialect;
+
+/**
+ * This is a custom dialect used to register custom Postgres functions
+ * https://www.zymr.com/postgresql-full-text-searchfts-hibernate/
+ */
+public class CustomPostgreSQL9Dialect extends PostgreSQL9Dialect {
+
+    public CustomPostgreSQL9Dialect() {
+        registerFunction("fts", new FTSFunction());
+    }
+}

--- a/src/main/java/com/monumental/FTSFunction.java
+++ b/src/main/java/com/monumental/FTSFunction.java
@@ -1,0 +1,43 @@
+package com.monumental;
+
+import org.hibernate.QueryException;
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.type.BooleanType;
+import org.hibernate.type.Type;
+
+import java.util.List;
+
+/**
+ * This function allows us to leverage Postgres's FTS (Full Text Search) from within Hibernate.
+ * https://www.zymr.com/postgresql-full-text-searchfts-hibernate/
+ */
+public class FTSFunction implements SQLFunction {
+
+    @Override
+    public String render(Type firstArgumentType, List args, SessionFactoryImplementor factory) {
+        if (args == null || args.size() != 2) {
+            throw new IllegalArgumentException("The function must be passed exactly 2 arguments");
+        }
+
+        String field = (String) args.get(0);
+        String value = (String) args.get(1);
+        return "to_tsvector(" + field + ") @@ " + "plainto_tsquery(" + value + ")";
+    }
+
+    @Override
+    public boolean hasArguments() {
+        return true;
+    }
+
+    @Override
+    public boolean hasParenthesesIfNoArguments() {
+        return false;
+    }
+
+    @Override
+    public Type getReturnType(final Type firstArgumentType, final Mapping mapping) throws QueryException {
+        return new BooleanType();
+    }
+}

--- a/src/main/java/com/monumental/controllers/SearchController.java
+++ b/src/main/java/com/monumental/controllers/SearchController.java
@@ -1,0 +1,35 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Monument;
+import com.monumental.services.MonumentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+public class SearchController {
+
+    @Autowired
+    private MonumentService monumentService;
+
+    /**
+     * This function lets you search monuments using the q query param
+     * Ex: GET http://localhost:8080/api/search?q=Memorial
+     * TODO: Possibly search related tables such as Tags
+     * @param q The search query string
+     * @return  Matching Monuments based on their title
+     */
+    @GetMapping("/api/search")
+    public List<Monument> searchMonuments(@RequestParam String q) {
+        try {
+            return this.monumentService.search(q);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/monumental/controllers/SearchController.java
+++ b/src/main/java/com/monumental/controllers/SearchController.java
@@ -25,11 +25,6 @@ public class SearchController {
      */
     @GetMapping("/api/search")
     public List<Monument> searchMonuments(@RequestParam String q) {
-        try {
-            return this.monumentService.search(q);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return new ArrayList<>();
+        return this.monumentService.search(q);
     }
 }

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -1,7 +1,15 @@
 package com.monumental.services;
 
 import com.monumental.models.Monument;
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 @Service
 public class MonumentService extends ModelService<Monument> {
@@ -22,5 +30,36 @@ public class MonumentService extends ModelService<Monument> {
 
     }
 
-    // Add Monument specific database operations here if needed
+    /**
+     * Uses the FTS function to search for matching Monuments by title
+     * TODO: Search other fields besides title
+     * @param query The search string
+     * @return      Matching Monuments by title
+     */
+    @SuppressWarnings("unchecked")
+    public List<Monument> search(String query) {
+        Session session = this.sessionFactoryService.getFactory().openSession();
+        Transaction transaction = null;
+        List<Monument> records;
+
+        try {
+            transaction = session.beginTransaction();
+            // The "fts" function is defined by the FTSFunction and CustomPostgreSQL9Dialect classes
+            Query q = session.createQuery(
+                "select m from Monument m where fts(m.title, :query) = true"
+            ).setParameter("query", query);
+            records = q.list();
+            transaction.commit();
+
+            session.close();
+        } catch (HibernateException e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            session.close();
+            throw e;
+        }
+
+        return new ArrayList<>(new HashSet<>(records));
+    }
 }

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -4,7 +4,7 @@
 <hibernate-configuration>
     <session-factory>
         <property name="hibernate.dialect">
-            org.hibernate.dialect.PostgreSQL9Dialect
+            com.monumental.CustomPostgreSQL9Dialect
         </property>
 
         <property name="hibernate.connection.driver_class">


### PR DESCRIPTION
This PR uses [this](https://www.zymr.com/postgresql-full-text-searchfts-hibernate/) article as a guide to using Postgres's Full Text Search (FTS) feature from within Hibernate

[This](http://rachbelaid.com/postgres-full-text-search-is-good-enough/) article provides a good non-hibernate explanation of how searching works in Postgres and what features exist

This adds the endpoint `GET /api/search`. Currently this just searches monuments' titles, so we will need to improve it down the road. Here's some example requests and responses, these are intentionally small results, if you search something like "memorial" you will get hundreds of results obviously:

```
GET /api/search?q=oregon
```
```JSON
[
    {
        "id": 964,
        "createdDate": "2019-10-09",
        "updatedDate": "2019-10-09",
        "artist": "Atlas Landscape Architecture",
        "title": "Oregon Holocaust Memorial",
        "date": "2004-01-01",
        "material": "",
        "lat": 0,
        "lon": 0,
        "city": "Portland",
        "state": "OR ",
        "address": null,
        "description": "The Oregon Holocaust Memorial in Portland, OR  was created by Atlas Landscape Architecture in 2004.",
        "inscription": null,
        "coordinatePointAsString": "0.0, 0.0"
    },
    {
        "id": 941,
        "createdDate": "2019-10-09",
        "updatedDate": "2019-10-09",
        "artist": "Walker Macy Architecture",
        "title": "Oregon Vientam Veterans Memorial",
        "date": "1982-01-01",
        "material": "metal",
        "lat": 45.512,
        "lon": -122.71857,
        "city": "Portland",
        "state": "OR ",
        "address": null,
        "description": "The Oregon Vientam Veterans Memorial in Portland, OR  was created by Walker Macy Architecture in 1982.",
        "inscription": null,
        "coordinatePointAsString": "45.512, -122.71857"
    }
]
```

```
GET /api/search?q=Vientam
```
```JSON
[
    {
        "id": 941,
        "createdDate": "2019-10-09",
        "updatedDate": "2019-10-09",
        "artist": "Walker Macy Architecture",
        "title": "Oregon Vientam Veterans Memorial",
        "date": "1982-01-01",
        "material": "metal",
        "lat": 45.512,
        "lon": -122.71857,
        "city": "Portland",
        "state": "OR ",
        "address": null,
        "description": "The Oregon Vientam Veterans Memorial in Portland, OR  was created by Walker Macy Architecture in 1982.",
        "inscription": null,
        "coordinatePointAsString": "45.512, -122.71857"
    }
]
```