### PR TITLE
Add isPrimary Field to Images

### DIFF
--- a/src/main/java/com/monumental/models/Image.java
+++ b/src/main/java/com/monumental/models/Image.java
@@ -18,6 +18,9 @@ public class Image extends Model implements Serializable {
     @Column(name = "url")
     private String url;
 
+    @Column(name = "is_primary")
+    private boolean isPrimary;
+
     @ManyToOne
     @JoinColumn(name = "monument_id", nullable = false)
     private Monument monument;
@@ -32,6 +35,14 @@ public class Image extends Model implements Serializable {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public boolean getIsPrimary() {
+        return this.isPrimary;
+    }
+
+    public void setIsPrimary(boolean isPrimary) {
+        this.isPrimary = isPrimary;
     }
 
     public Monument getMonument() {


### PR DESCRIPTION
This PR adds a boolean `isPrimary` field to Image. We'll be able to use this later on to determine what image to display first on the View M&M page as well as the thumbnail throughout the website.