### PR TITLE
Fix the gallery animation when switching quickly between images

### DIFF
--- a/client/src/components/Gallery/Gallery.js
+++ b/client/src/components/Gallery/Gallery.js
@@ -142,6 +142,7 @@ export default class Gallery extends React.Component {
             <div className="animation image" style={{
                 backgroundImage: animating ? `url(${animationImage.url})` : null,
                 opacity: animating ? 1 : 0,
+                transitionDuration: animating ? '1s' : '0s',
                 visibility: animating ? 'visible' : 'hidden'
             }}/>
         )

--- a/client/src/components/Gallery/Gallery.scss
+++ b/client/src/components/Gallery/Gallery.scss
@@ -102,7 +102,7 @@
     width: 100%;
     height: 100%;
     position: absolute;
-    transition: opacity 1s ease-in;
+    transition: opacity ease-in;
     top: 0;
     z-index: 1;
 }


### PR DESCRIPTION
I figured out why the animation didn't play or seemed to play too quickly when you would quickly click between images. Basically, after an animation finishes we set the image's opacity back to 1 while its visibility is hidden. However, there was a transition happening for 1s on this even though it was hidden, so if you started a new animation during this 1s period it would actually have less than 1 opacity at the start of the animation.

To fix this, the animation duration is set to 0 when the image is hidden so that it instantly returns to opacity of 1 and can start a new animation at any time.