### PR TITLE
Optimize search query to prevent in memory pagination

### DIFF
--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -1,13 +1,15 @@
 package com.monumental.services;
 
 import com.monumental.models.Monument;
+import com.monumental.models.Tag;
 import com.vividsolutions.jts.geom.Geometry;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.criteria.*;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-
-import static com.monumental.util.string.StringHelper.isNullOrEmpty;
+import java.util.Map;
 
 @Service
 public class MonumentService extends ModelService<Monument> {
@@ -38,24 +40,24 @@ public class MonumentService extends ModelService<Monument> {
     private void buildSimilarityQuery(CriteriaBuilder builder, CriteriaQuery query, Root root, String searchQuery,
                                       Double threshold, Boolean orderByResults) {
         query.where(
-            builder.or(
-                builder.gt(builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)), threshold),
-                builder.gt(builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery)), threshold),
-                builder.gt(builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery)), threshold)
-            )
+                builder.or(
+                        builder.gt(builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)), threshold),
+                        builder.gt(builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery)), threshold),
+                        builder.gt(builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery)), threshold)
+                )
         );
 
         if (orderByResults) {
             query.orderBy(
-                builder.desc(
-                    builder.sum(
-                        builder.sum(
-                                builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)),
-                                builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery))
-                        ),
-                        builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery))
+                    builder.desc(
+                            builder.sum(
+                                    builder.sum(
+                                            builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)),
+                                            builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery))
+                                    ),
+                                    builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery))
+                            )
                     )
-                )
             );
         }
     }
@@ -89,7 +91,7 @@ public class MonumentService extends ModelService<Monument> {
                                 ),
                                 builder.literal(feet)
                         ),
-                true)
+                        true)
         );
     }
 
@@ -105,11 +107,11 @@ public class MonumentService extends ModelService<Monument> {
      */
     @SuppressWarnings("unchecked")
     private void buildSearchQuery(CriteriaBuilder builder, CriteriaQuery query, Root root, String searchQuery,
-                                           String latitude, String longitude, String distance) {
+                                  String latitude, String longitude, String distance, Boolean orderByResults) {
         // TODO: Query for tags
         // TODO: Filters
         if (searchQuery != null) {
-            this.buildSimilarityQuery(builder, query, root, searchQuery, 0.1, true);
+            this.buildSimilarityQuery(builder, query, root, searchQuery, 0.1, orderByResults);
         }
 
         if (latitude != null && longitude != null && distance != null) {
@@ -134,17 +136,17 @@ public class MonumentService extends ModelService<Monument> {
         CriteriaBuilder builder = this.getCriteriaBuilder();
         CriteriaQuery<Monument> query = this.createCriteriaQuery(builder, false);
         Root<Monument> root = this.createRoot(query);
-        root.fetch("tags", JoinType.LEFT);
         query.select(root);
 
-        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance);
+        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, true);
 
         List<Monument> monuments = limit != null
-                                        ? page != null
-                                            ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
-                                            : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
-                                        : this.getWithCriteriaQuery(query);
+                ? page != null
+                ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
+                : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
+                : this.getWithCriteriaQuery(query);
 
+        this.getRelatedTags(monuments);
         return monuments;
     }
 
@@ -157,8 +159,41 @@ public class MonumentService extends ModelService<Monument> {
         Root<Monument> root = query.from(Monument.class);
         query.select(builder.countDistinct(root));
 
-        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance);
+        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, false);
 
         return this.getEntityManager().createQuery(query).getSingleResult().intValue();
+    }
+
+    /**
+     * Gets the related monuments and sets them on the monument objects, using only one extra SQL query
+     * @param monuments Monuments to get tags for - these objects are updated directly using setTags
+     *                  but no database update is called
+     */
+    public void getRelatedTags(List<Monument> monuments) {
+        CriteriaBuilder builder = this.getCriteriaBuilder();
+        CriteriaQuery<Monument> query = this.createCriteriaQuery(builder, false);
+        Root<Monument> root = this.createRoot(query);
+        query.select(root);
+        root.fetch("tags", JoinType.LEFT);
+
+        List<Integer> ids = new ArrayList<>();
+        for (Monument monument : monuments) {
+            ids.add(monument.getId());
+        }
+
+        query.where(
+                root.get("id").in(ids)
+        );
+
+        List<Monument> monumentsWithTags = this.getWithCriteriaQuery(query);
+
+        Map<Integer, List<Tag>> tagsMap = new HashMap<>();
+        for (Monument monument : monumentsWithTags) {
+            tagsMap.put(monument.getId(), monument.getTags());
+        }
+
+        for (Monument monument : monuments) {
+            monument.setTags(tagsMap.get(monument.getId()));
+        }
     }
 }

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -141,10 +141,10 @@ public class MonumentService extends ModelService<Monument> {
         this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, true);
 
         List<Monument> monuments = limit != null
-                                    ? page != null
-                                        ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
-                                        : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
-                                    : this.getWithCriteriaQuery(query);
+                                        ? page != null
+                                            ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
+                                            : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
+                                        : this.getWithCriteriaQuery(query);
 
         this.getRelatedTags(monuments);
         return monuments;

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -141,10 +141,10 @@ public class MonumentService extends ModelService<Monument> {
         this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, true);
 
         List<Monument> monuments = limit != null
-                ? page != null
-                ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
-                : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
-                : this.getWithCriteriaQuery(query);
+                                    ? page != null
+                                        ? this.getWithCriteriaQuery(query, Integer.parseInt(limit), (Integer.parseInt(page)) - 1)
+                                        : this.getWithCriteriaQuery(query, Integer.parseInt(limit))
+                                    : this.getWithCriteriaQuery(query);
 
         this.getRelatedTags(monuments);
         return monuments;

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -40,24 +40,24 @@ public class MonumentService extends ModelService<Monument> {
     private void buildSimilarityQuery(CriteriaBuilder builder, CriteriaQuery query, Root root, String searchQuery,
                                       Double threshold, Boolean orderByResults) {
         query.where(
-                builder.or(
-                        builder.gt(builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)), threshold),
-                        builder.gt(builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery)), threshold),
-                        builder.gt(builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery)), threshold)
-                )
+            builder.or(
+                builder.gt(builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)), threshold),
+                builder.gt(builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery)), threshold),
+                builder.gt(builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery)), threshold)
+            )
         );
 
         if (orderByResults) {
             query.orderBy(
-                    builder.desc(
-                            builder.sum(
-                                    builder.sum(
-                                            builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)),
-                                            builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery))
-                                    ),
-                                    builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery))
-                            )
+                builder.desc(
+                    builder.sum(
+                        builder.sum(
+                            builder.function("similarity", Number.class, root.get("title"), builder.literal(searchQuery)),
+                            builder.function("similarity", Number.class, root.get("artist"), builder.literal(searchQuery))
+                        ),
+                        builder.function("similarity", Number.class, root.get("description"), builder.literal(searchQuery))
                     )
+                )
             );
         }
     }
@@ -77,21 +77,21 @@ public class MonumentService extends ModelService<Monument> {
         Integer feet = miles * 5280;
 
         query.where(
-                builder.equal(
-                        builder.function("ST_DWithin", Boolean.class,
-                                builder.function("ST_Transform", Geometry.class, root.get("coordinates"),
-                                        builder.literal(feetSrid)
-                                ),
-                                builder.function("ST_Transform", Geometry.class,
-                                        builder.function("ST_GeometryFromText", Geometry.class,
-                                                builder.literal(comparisonPointAsString),
-                                                builder.literal(coordinateSrid)
-                                        ),
-                                        builder.literal(feetSrid)
-                                ),
-                                builder.literal(feet)
+            builder.equal(
+                builder.function("ST_DWithin", Boolean.class,
+                    builder.function("ST_Transform", Geometry.class, root.get("coordinates"),
+                        builder.literal(feetSrid)
+                    ),
+                    builder.function("ST_Transform", Geometry.class,
+                        builder.function("ST_GeometryFromText", Geometry.class,
+                            builder.literal(comparisonPointAsString),
+                            builder.literal(coordinateSrid)
                         ),
-                        true)
+                        builder.literal(feetSrid)
+                    ),
+                    builder.literal(feet)
+                ),
+         true)
         );
     }
 

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -165,7 +165,7 @@ public class MonumentService extends ModelService<Monument> {
     }
 
     /**
-     * Gets the related monuments and sets them on the monument objects, using only one extra SQL query
+     * Gets the related tags and sets them on the monument objects, using only one extra SQL query
      * @param monuments Monuments to get tags for - these objects are updated directly using setTags
      *                  but no database update is called
      */


### PR DESCRIPTION
There's a pretty annoying "quirk" with JPA 2 where you can't do joins when you're using a limit clause, which causes JPA to then do the limit in memory.

In other words, because we were getting tags alongside the monuments, JPA was querying the entire monument table and then doing a limit in memory, which is terrible and defeats the entire purpose of pagination.

To fix this, we now do the first monument query with the limit but don't get any of the tags. Then, we do another monument query using an IN clause for the ids from the previous query and join the tag table, giving us the same monuments with their tags, which we can then set on the first list of monuments.

End result, we get limited monuments (done through SQL instead of in memory in Java), and we get their related tags.

This also fixes a bug where the count query was failing