### PR TITLE
Get related monuments by most matching tags

### DIFF
--- a/client/src/actions/monument.js
+++ b/client/src/actions/monument.js
@@ -96,16 +96,19 @@ export default function fetchMonument(id) {
             dispatch(fetchNearbyMonumentsError(error));
         }
 
-        const tags = res.tags.map(tag => tag.name);
+        const tags = (res.tags || [])
+                    .concat(res.materials || [])
+                    .map(tag => tag.name);
         if (tags.length > 0) {
             queryOptions = {
                 tags: tags,
-                limit: 6
+                limit: 6,
+                monumentId: id
             };
             queryString = QueryString.stringify(queryOptions, {arrayFormat: 'comma'});
             dispatch(fetchRelatedMonumentsPending());
             try {
-                const relatedMonuments = await get(`/api/search/monuments/?${queryString}`);
+                const relatedMonuments = await get(`/api/monuments/related/?${queryString}`);
                 dispatch(fetchRelatedMonumentsSuccess(relatedMonuments));
             } catch (error) {
                 dispatch(fetchRelatedMonumentsError(error));

--- a/client/src/components/Monument/Details/Details.js
+++ b/client/src/components/Monument/Details/Details.js
@@ -42,7 +42,7 @@ export default class Details extends React.Component {
                             <div className="field font-italic"><Address monument={monument}/></div>
                             <div className="field">{monument.description}</div>
                         </div>
-                        <Tags tags={monument.tags}/>
+                        <Tags tags={(monument.materials || []).concat(monument.tags || [])}/>
                     </div>
                 </div>
                 <Gallery images={images}/>

--- a/src/main/java/com/monumental/controllers/MonumentController.java
+++ b/src/main/java/com/monumental/controllers/MonumentController.java
@@ -52,4 +52,10 @@ public class MonumentController {
         this.monumentRepository.save(monument);
         return monument;
     }
-}
+
+    @GetMapping("/api/monuments/related")
+    public List<Monument> getRelatedMonumentsByTags(@RequestParam List<String> tags,
+                                                    @RequestParam Integer monumentId,
+                                                    @RequestParam(required = false, defaultValue = "10") Integer limit) {
+        return this.monumentService.getRelatedMonumentsByTags(tags, monumentId, limit);
+    }}

--- a/src/main/java/com/monumental/repositories/MonumentRepository.java
+++ b/src/main/java/com/monumental/repositories/MonumentRepository.java
@@ -1,11 +1,13 @@
 package com.monumental.repositories;
 
 import com.monumental.models.Monument;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.Tuple;
 import javax.transaction.Transactional;
 import java.util.List;
 
@@ -19,5 +21,15 @@ public interface MonumentRepository extends JpaRepository<Monument, Integer> {
      */
     @Query("select m from Monument m join m.tags tag where tag.id = :id")
     List<Monument> getAllByTagId(@Param("id") Integer id);
+
+    /**
+     * Searches for monuments with matching tags by name, returning those with the most matching tags
+     * @param names - The tag names to match against
+     * @param monumentId - The monument to exclude from search results
+     * @param pageable - Used to give the search a limit
+     * @return Tuples of monuments with their count of matching tags
+     */
+    @Query("select m, count(t.id) as c from Monument m join m.tags t where t.name in :names and m.id <> :id group by m.id order by c desc")
+    List<Tuple> getRelatedMonuments(@Param("names") List<String> names, @Param("id") Integer monumentId, Pageable pageable);
 
 }


### PR DESCRIPTION
This fixes the related tags implementation so that monuments with one or more matching tags are returned rather than needing all tags to match, and the monuments with the most matches are displayed first.

This does not affect the tag searching on the search page. I could not find a viable way to do this within that `CriteriaQuery`, but the behavior we have there now is probably sufficient anyway.