### PR TITLE
Fix Nearby Monuments Query

### DIFF
--- a/client/src/actions/monument.js
+++ b/client/src/actions/monument.js
@@ -85,7 +85,7 @@ export default function fetchMonument(id) {
             lat: res.lat,
             lon: res.lon,
             d: 25,
-            limit: 6
+            limit: 5
         };
         let queryString = QueryString.stringify(queryOptions);
         dispatch(fetchNearbyMonumentsPending());


### PR DESCRIPTION
This PR fixes the limit option for the Nearby Monuments query. It was 6 and is now 5.