### PR TITLE
Make AWS API Keys Configurable Through Environment Variables

### DIFF
--- a/client/src/utils/api-util.js
+++ b/client/src/utils/api-util.js
@@ -47,8 +47,8 @@ export default async function uploadImagesToS3(images) {
     // Setup the global AWS config
     AWS.config.update({
         region: 'us-east-2',
-        accessKeyId: '',
-        secretAccessKey: ''
+        accessKeyId: `${process.env.REACT_APP_AWS_ACCESS_KEY_ID}`,
+        secretAccessKey: `${process.env.REACT_APP_AWS_SECRET_ACCESS_KEY}`
     });
 
     let imageUrls = [];


### PR DESCRIPTION
This PR makes the AWS API keys used to store images into the S3 bucket configurable through the `.env` file.