### PR TITLE
Implement distance and date sorting in search results

### DIFF
--- a/client/src/actions/monument.js
+++ b/client/src/actions/monument.js
@@ -85,7 +85,8 @@ export default function fetchMonument(id) {
             lat: res.lat,
             lon: res.lon,
             d: 25,
-            limit: 5
+            limit: 5,
+            sort: 'distance'
         };
         let queryString = QueryString.stringify(queryOptions);
         dispatch(fetchNearbyMonumentsPending());

--- a/client/src/components/Search/Search.js
+++ b/client/src/components/Search/Search.js
@@ -38,7 +38,7 @@ export default class Search extends React.Component {
     }
 
     render() {
-        const { monuments, onLimitChange, lat, lon, distance, onFilterChange, tags, materials } = this.props;
+        const { monuments, onLimitChange, onSortChange, lat, lon, sort, distance, onFilterChange, tags, materials } = this.props;
         const [ count, page, limit ] = [ this.props.count, this.props.page, this.props.limit ]
             .map(value => parseInt(value) || 0);
 
@@ -54,7 +54,10 @@ export default class Search extends React.Component {
                             <Filters onChange={filters => onFilterChange(filters)}
                                      showDistance={lat && lon} distance={distance}
                                      tags={tags} materials={materials}/>
-                            <SearchInfo count={count} page={page} limit={limit} onLimitChange={onLimitChange}/>
+                            <SearchInfo count={count} page={page} limit={limit} sort={sort}
+                                        onLimitChange={onLimitChange}
+                                        onSortChange={onSortChange}
+                                        showDistanceSort={lat && lon}/>
                         </div>
                         <div className="search-results">
                             <SearchResults monuments={monuments} limit={limit} page={page}/>

--- a/client/src/components/Search/SearchInfo/SearchInfo.js
+++ b/client/src/components/Search/SearchInfo/SearchInfo.js
@@ -6,7 +6,7 @@ export default class SearchInfo extends React.Component {
     limitOptions = [10, 25, 50, 100];
 
     render() {
-        const { onLimitChange, limit, page, count } = this.props;
+        const { onLimitChange, onSortChange, limit, page, count, sort, showDistanceSort } = this.props;
 
         const pageEnd = Math.min((limit * (page - 1)) + limit, count);
         const pageStart = Math.min((limit * (page - 1)) + 1, pageEnd);
@@ -28,9 +28,13 @@ export default class SearchInfo extends React.Component {
                 </div>
                 <div>
                     <span>Sort by</span>
-                    <Form.Control as="select" className="ml-2">
-                        <option>Relevance</option>
-                        <option>Distance</option>
+                    <Form.Control as="select" className="ml-2" defaultValue={sort} onChange={event => onSortChange(event.target.value)} >
+                        <option value="relevance">Relevance</option>
+                        {
+                            showDistanceSort ? <option value="distance">Distance</option> : null
+                        }
+                        <option value="newest">Date Created (Newest First)</option>
+                        <option value="oldest">Date Created (Oldest First)</option>
                     </Form.Control>
                 </div>
             </div>

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -52,7 +52,7 @@ class SearchPage extends React.Component {
                 <Spinner show={pending}/>
                 <Search monuments={monuments} {...this.getQueryParams()} count={count}
                         onLimitChange={this.handleLimitChange.bind(this)} onPageChange={this.handlePageChange.bind(this)}
-                        onFilterChange={this.handleFilterChange.bind(this)}/>
+                        onFilterChange={this.handleFilterChange.bind(this)} onSortChange={this.handleSortChange.bind(this)}/>
             </div>
         );
     }
@@ -77,6 +77,12 @@ class SearchPage extends React.Component {
     handleFilterChange(filters) {
         this.search({
             d: filters.distance
+        });
+    }
+
+    handleSortChange(sort) {
+        this.search({
+            sort
         });
     }
 

--- a/src/main/java/com/monumental/controllers/SearchController.java
+++ b/src/main/java/com/monumental/controllers/SearchController.java
@@ -30,6 +30,7 @@ public class SearchController {
      * @param latitude - The latitude of the comparison point
      * @param longitude - The longitude of the comparison point
      * @param distance - The distance from the comparison point to search in, units of miles
+     * @param sortType - The way in which to sort the results by
      * @return            Matching Monuments based on their title, artist or location
      */
     @GetMapping("/api/search/monuments")
@@ -40,8 +41,12 @@ public class SearchController {
                                           @RequestParam(required = false, value = "lon") Double longitude,
                                           @RequestParam(required = false, value = "d", defaultValue = "25") Integer distance,
                                           @RequestParam(required = false) List<String> tags,
-                                          @RequestParam(required = false) List<String> materials) {
-        return this.monumentService.search(searchQuery, page, limit, latitude, longitude, distance, tags, materials);
+                                          @RequestParam(required = false) List<String> materials,
+                                          @RequestParam(required = false, value = "sort", defaultValue = "relevance") String sortType) {
+        return this.monumentService.search(
+                searchQuery, page, limit, latitude, longitude, distance, tags, materials,
+                MonumentService.SortType.valueOf(sortType.toUpperCase())
+        );
     }
 
     /**

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -41,6 +41,13 @@ public class MonumentService extends ModelService<Monument> {
     public static final int feetSrid = 2877;
 
     /**
+     * This enum is used when choosing how to sort search results
+     */
+    public enum SortType {
+        RELEVANCE, DISTANCE, NEWEST, OLDEST, NONE;
+    }
+
+    /**
      * Builds a similarity query on the Monument's title, artist and description fields, and adds them to your CriteriaQuery
      * @param builder           Your CriteriaBuilder
      * @param query             Your CriteriaQuery
@@ -75,28 +82,45 @@ public class MonumentService extends ModelService<Monument> {
     /**
      * Creates a PostGIS ST_DWithin query on the Monument's point field and adds it to the specified CriteriaQuery
      * @param builder The CriteriaBuilder for the query
+     * @param query The CriteriaQuery being created
      * @param root The Root associated with the CriteriaQuery
      * @param latitude The latitude of the point to compare to
      * @param longitude The longitude of the point to compare to
-     * @param miles - The number of miles from the comparison point to check
+     * @param miles The number of miles from the comparison point to check
+     * @param orderByDistance If true, results will be ordered by distance ascending
      */
-    private Predicate buildDWithinQuery(CriteriaBuilder builder, Root root, Double latitude, Double longitude, Integer miles) {
+    private Predicate buildDWithinQuery(CriteriaBuilder builder, CriteriaQuery query, Root root, Double latitude, Double longitude,
+                                        Integer miles, Boolean orderByDistance) {
         String comparisonPointAsString = "POINT(" + longitude + " " + latitude + ")";
         Integer feet = miles * 5280;
 
+        Expression[] expressions = new Expression[]{
+            builder.function("ST_Transform", Geometry.class, root.get("coordinates"),
+                builder.literal(feetSrid)
+            ),
+            builder.function("ST_Transform", Geometry.class,
+                builder.function("ST_GeometryFromText", Geometry.class,
+                    builder.literal(comparisonPointAsString),
+                    builder.literal(coordinateSrid)
+                ),
+                builder.literal(feetSrid)
+            ),
+            builder.literal(feet)
+        };
+
+        if (orderByDistance) {
+            query.orderBy(
+                builder.asc(
+                    builder.function("ST_Distance", Long.class,
+                        expressions[0], expressions[1]
+                    )
+                )
+            );
+        }
+
         return builder.equal(
             builder.function("ST_DWithin", Boolean.class,
-                builder.function("ST_Transform", Geometry.class, root.get("coordinates"),
-                    builder.literal(feetSrid)
-                ),
-                builder.function("ST_Transform", Geometry.class,
-                    builder.function("ST_GeometryFromText", Geometry.class,
-                        builder.literal(comparisonPointAsString),
-                        builder.literal(coordinateSrid)
-                    ),
-                    builder.literal(feetSrid)
-                ),
-                builder.literal(feet)
+                expressions[0], expressions[1], expressions[2]
             ),
      true);
     }
@@ -154,19 +178,38 @@ public class MonumentService extends ModelService<Monument> {
      * @param distance - The distance from the comparison point to search in, units of miles
      * @param tags - List of tag names to search by
      * @param materials - List of material tag names to search by
+     * @param sortType - The way in which to sort the results by
      */
     private void buildSearchQuery(CriteriaBuilder builder, CriteriaQuery query, Root root, String searchQuery,
                                   Double latitude, Double longitude, Integer distance, List<String> tags,
-                                  List<String> materials, Boolean orderByResults) {
+                                  List<String> materials, SortType sortType) {
 
         List<Predicate> predicates = new ArrayList<>();
 
+        boolean sortByRelevance = false;
+        boolean sortByDistance = false;
+
+        switch (sortType) {
+            case NEWEST:
+                this.sortByDate(builder, query, root, true);
+                break;
+            case OLDEST:
+                this.sortByDate(builder, query, root, false);
+                break;
+            case DISTANCE:
+                sortByDistance = true;
+            case RELEVANCE:
+                sortByRelevance = true;
+            default:
+                break;
+        }
+
         if (!isNullOrEmpty(searchQuery)) {
-            predicates.add(this.buildSimilarityQuery(builder, query, root, searchQuery, 0.1, orderByResults));
+            predicates.add(this.buildSimilarityQuery(builder, query, root, searchQuery, 0.1, sortByRelevance));
         }
 
         if (latitude != null && longitude != null && distance != null) {
-            predicates.add(this.buildDWithinQuery(builder, root, latitude, longitude, distance));
+            predicates.add(this.buildDWithinQuery(builder, query, root, latitude, longitude, distance, sortByDistance));
         }
 
         if (tags != null && tags.size() > 0) {
@@ -200,16 +243,17 @@ public class MonumentService extends ModelService<Monument> {
      * @param distance - The distance from the comparison point to search in, units of miles
      * @param tags - List of tag names to search by
      * @param materials - List of material tag names to search by
+     * @param sortType - The way in which to sort the results by
      * @return List<Monument> - List of Monument results based on the specified search parameters
      */
     public List<Monument> search(String searchQuery, String page, String limit, Double latitude, Double longitude,
-                                 Integer distance, List<String> tags, List<String> materials) {
+                                 Integer distance, List<String> tags, List<String> materials, SortType sortType) {
         CriteriaBuilder builder = this.getCriteriaBuilder();
         CriteriaQuery<Monument> query = this.createCriteriaQuery(builder, false);
         Root<Monument> root = this.createRoot(query);
         query.select(root);
 
-        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, tags, materials, true);
+        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, tags, materials, sortType);
 
         List<Monument> monuments = limit != null
                                         ? page != null
@@ -232,7 +276,7 @@ public class MonumentService extends ModelService<Monument> {
         Root<Monument> root = query.from(Monument.class);
         query.select(builder.countDistinct(root));
 
-        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, tags, materials, false);
+        this.buildSearchQuery(builder, query, root, searchQuery, latitude, longitude, distance, tags, materials, SortType.NONE);
 
         return this.getEntityManager().createQuery(query).getSingleResult().intValue();
     }
@@ -396,5 +440,20 @@ public class MonumentService extends ModelService<Monument> {
         } catch (ParseException e) {
             return null;
         }
+    }
+
+    /**
+     * Sort the query by the monuments' date field
+     * @param builder The CriteriaBuilder for the query
+     * @param query The CriteriaQuery being created
+     * @param root The Root associated with the CriteriaQuery
+     * @param newestFirst If true, the results will be sorted in descending order
+     */
+    private void sortByDate(CriteriaBuilder builder, CriteriaQuery query, Root root, Boolean newestFirst) {
+        query.orderBy(
+            newestFirst ?
+                builder.desc(root.get("date")) :
+                builder.asc(root.get("date"))
+        );
     }
 }

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -198,9 +198,9 @@ public class MonumentService extends ModelService<Monument> {
                 break;
             case DISTANCE:
                 sortByDistance = true;
+                break;
             case RELEVANCE:
                 sortByRelevance = true;
-            default:
                 break;
         }
 


### PR DESCRIPTION
This PR adds distance and date (newest first or oldest first) sorting to the search page, and also makes the existing dropdown functional.

I'm not gonna lie, I don't really know what the default sort is if you do relevance without a text search. I think it's probably based on when the row was inserted into the database, probably oldest first
![image](https://user-images.githubusercontent.com/25756457/70068840-be5da880-15be-11ea-9313-9508fb3a9cb7.png)

Distance sort
![image](https://user-images.githubusercontent.com/25756457/70068890-d9301d00-15be-11ea-9e4d-ff030b18191a.png)

Oldest (Canton Viaduct is from 1835)
![image](https://user-images.githubusercontent.com/25756457/70068913-e4834880-15be-11ea-9522-65ee79818384.png)

Newest (Boston Irish Famine Memorial is from 1998)
![image](https://user-images.githubusercontent.com/25756457/70068998-04b30780-15bf-11ea-83cd-bb0c7ba69ed2.png)

