### PR TITLE
View M+M Page Enhancements

### DIFF
--- a/client/src/components/Monument/Details/About/About.js
+++ b/client/src/components/Monument/Details/About/About.js
@@ -12,12 +12,109 @@ export default class About extends React.Component {
 
         const { monument, contributions, references } = this.props;
 
-        let lastUpdated = (
-            <div>
-                <span className="detail-label">Last Updated:&nbsp;</span>
-                {this.prettyPrintDate(monument.updatedDate)}
-            </div>
-        );
+        let title;
+        if (monument.title) {
+            title = (
+                <div>
+                    <span className='detail-label'>Title:&nbsp;</span>
+                    {monument.title}
+                </div>
+            );
+        }
+
+        let artist;
+        if (monument.artist) {
+            artist = (
+                <div>
+                    <span className='detail-label'>Artist:&nbsp;</span>
+                    {monument.artist}
+                </div>
+            );
+        }
+
+        let date;
+        if (monument.date) {
+            date = (
+                <div>
+                    <span className='detail-label'>Date:&nbsp;</span>
+                    {this.prettyPrintDate(monument.date)}
+                </div>
+            );
+        }
+
+        let city;
+        if (monument.city) {
+            city = (
+                <div>
+                    <span className='detail-label'>City:&nbsp;</span>
+                    {monument.city}
+                </div>
+            );
+        }
+
+        let state;
+        if (monument.state) {
+            state = (
+                <div>
+                    <span className='detail-label'>State:&nbsp;</span>
+                    {monument.state}
+                </div>
+            );
+        }
+
+        let address;
+        if (monument.address) {
+            address = (
+                <div>
+                    <span className='detail-label'>Address:&nbsp;</span>
+                    {monument.address}
+                </div>
+            )
+        }
+
+        let coordinates;
+        if (monument.coordinates) {
+            coordinates = (
+                <div>
+                    <span className='detail-label'>Coordinates:&nbsp;</span>
+                    {monument.coordinates.coordinates[1]}, {monument.coordinates.coordinates[0]}
+                </div>
+            );
+        }
+
+        let materialsList;
+        if (monument.materials && monument.materials.length) {
+            materialsList = (
+                <div>
+                    <span className='detail-label'>Materials:&nbsp;</span>
+                    <ul>
+                        {monument.materials.map(material => <li key={material.id}>{material.name}</li>)}
+                    </ul>
+                </div>
+            );
+        }
+
+        let tagsList;
+        if (monument.tags && monument.tags.length) {
+            tagsList = (
+                <div>
+                    <span className='detail-label'>Tags:&nbsp;</span>
+                    <ul>
+                        {monument.tags.map(tag => <li key={tag.id}>{tag.name}</li>)}
+                    </ul>
+                </div>
+            );
+        }
+
+        let lastUpdated;
+        if (monument.updatedDate) {
+            lastUpdated = (
+                <div>
+                    <span className='detail-label'>Last Updated:&nbsp;</span>
+                    {this.prettyPrintDate(monument.updatedDate)}
+                </div>
+            );
+        }
 
         let contributorsList;
         if (contributions && contributions.length) {
@@ -48,9 +145,18 @@ export default class About extends React.Component {
                 <Card.Title>About</Card.Title>
                 <Card.Body>
                     <div className="detail-list">
-                        {lastUpdated}
+                        {title}
+                        {artist}
+                        {date}
+                        {city}
+                        {state}
+                        {address}
+                        {coordinates}
+                        {materialsList}
+                        {tagsList}
                         {contributorsList}
                         {referencesList}
+                        {lastUpdated}
                     </div>
                 </Card.Body>
             </Card>

--- a/client/src/components/Monument/Monument.scss
+++ b/client/src/components/Monument/Monument.scss
@@ -123,7 +123,7 @@
 
     .card-body {
         margin-top: 0;
-        padding-top: 0;
+        padding-top: 0.5rem;
     }
 }
 

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -1,6 +1,7 @@
 package com.monumental.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.monumental.util.string.StringHelper;
 import com.vividsolutions.jts.geom.Point;
 import org.hibernate.LazyInitializationException;
 
@@ -238,17 +239,35 @@ public class Monument extends Model implements Serializable {
 
     /**
      * Generates a description of this Monument based on some of its state
+     * If the Monument does not have a title, no description is generated
+     * since Monuments should never have no title
      * @return String - the description of this Monument
      */
     private String generateDescription() {
+        if (this.title == null) {
+            return null;
+        }
+
         String description = "";
 
-        if (this.title != null) {
-            if (!this.title.toLowerCase().startsWith("the ")) {
-                description += "The ";
-            }
+        if (!this.title.toLowerCase().startsWith("the ")) {
+            description += "The ";
+        }
 
-            description += this.title + " in " + this.city + ", " + this.state + " was created by " + this.artist;
+        description += this.title;
+
+        if (!StringHelper.isNullOrEmpty(this.city) && !StringHelper.isNullOrEmpty(this.state)) {
+            description += " in " + this.city + ", " + this.state;
+        }
+        else if (!StringHelper.isNullOrEmpty(this.city) && StringHelper.isNullOrEmpty(this.state)) {
+            description += " in " + this.city;
+        }
+        else if (StringHelper.isNullOrEmpty(this.city) && !StringHelper.isNullOrEmpty(this.state)) {
+            description += " in " + this.state;
+        }
+
+        if (!StringHelper.isNullOrEmpty(this.artist)) {
+            description += " was created by " + this.artist;
         }
 
         if (this.date != null) {
@@ -257,6 +276,10 @@ public class Monument extends Model implements Serializable {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy");
 
             description += simpleDateFormat.format(this.date);
+        }
+
+        if (StringHelper.isNullOrEmpty(description)) {
+            return "";
         }
 
         description += ".";

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -271,15 +271,15 @@ public class Monument extends Model implements Serializable {
         }
 
         if (this.date != null) {
+            if (StringHelper.isNullOrEmpty(this.artist)) {
+                description += " was created";
+            }
+
             description += " in ";
 
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy");
 
             description += simpleDateFormat.format(this.date);
-        }
-
-        if (StringHelper.isNullOrEmpty(description)) {
-            return "";
         }
 
         description += ".";

--- a/src/test/java/com/monumental/models/unittest/MonumentUnitTests.java
+++ b/src/test/java/com/monumental/models/unittest/MonumentUnitTests.java
@@ -155,6 +155,42 @@ public class MonumentUnitTests {
         assertEquals("This is a Description", result);
     }
 
+    @Test
+    public void testMonument_getDescription_NotNullCityNullState() {
+        Monument monument = makeTestMonument("Title", "City", null, "Artist", new Date(), null);
+
+        String result = monument.getDescription();
+
+        assertEquals("The Title in City was created by Artist in 2019.", result);
+    }
+
+    @Test
+    public void testMonument_getDescription_NullCityNotNullState() {
+        Monument monument = makeTestMonument("Title", null, "State", "Artist", new Date(), null);
+
+        String result = monument.getDescription();
+
+        assertEquals("The Title in State was created by Artist in 2019.", result);
+    }
+
+    @Test
+    public void testMonument_getDescription_NullArtistNotNullDate() {
+        Monument monument = makeTestMonument("Title", "City", "State", null, new Date(), null);
+
+        String result = monument.getDescription();
+
+        assertEquals("The Title in City, State was created in 2019.", result);
+    }
+
+    @Test
+    public void testMonument_getDescription_NotNullArtistNullDate() {
+        Monument monument = makeTestMonument("Title", "City", "State", "Artist", null, null);
+
+        String result = monument.getDescription();
+
+        assertEquals("The Title in City, State was created by Artist.", result);
+    }
+
     /**
      * Helper function to make a test Monument based on the specified parameters
      * @param title - String to set the Monument's title to

--- a/src/test/java/com/monumental/models/unittest/MonumentUnitTests.java
+++ b/src/test/java/com/monumental/models/unittest/MonumentUnitTests.java
@@ -23,6 +23,13 @@ public class MonumentUnitTests {
     /** getDescription Tests **/
 
     @Test
+    public void testMonument_getDescription_NullTitle() {
+        Monument monument = makeTestMonument(null, "City", "State", "Artist", new Date(), null);
+
+        assertNull(monument.getDescription());
+    }
+
+    @Test
     public void testMonument_getDescription_TitleStartsWithThe_LowerCase() {
         Monument monument = makeTestMonument("the Title", "City", "State", "Artist", new Date(), null);
 


### PR DESCRIPTION
This PR makes some small enhancements to the View M+M Page:

1. Modifies the generated description for a Monument to better handle null fields
2. Adds to the About section a bit more information about the Monument

Screenshots of the new About section:
![image](https://user-images.githubusercontent.com/16584007/71327779-ad77c700-24da-11ea-96e8-39c9a571582e.png)
