### PR TITLE
Fixed Issue with View M+M Page

### DIFF
--- a/client/src/components/Monument/Details/About/About.js
+++ b/client/src/components/Monument/Details/About/About.js
@@ -37,7 +37,7 @@ export default class About extends React.Component {
             date = (
                 <div>
                     <span className='detail-label'>Date:&nbsp;</span>
-                    {this.prettyPrintDate(monument.date)}
+                    {prettyPrintDate(monument.date)}
                 </div>
             );
         }
@@ -111,7 +111,7 @@ export default class About extends React.Component {
             lastUpdated = (
                 <div>
                     <span className='detail-label'>Last Updated:&nbsp;</span>
-                    {this.prettyPrintDate(monument.updatedDate)}
+                    {prettyPrintDate(monument.updatedDate)}
                 </div>
             );
         }


### PR DESCRIPTION
This PR fixes the issue we saw when we were demoing the site earlier in our meeting. This issue was that we were using `this.prettyPrintDate()` when `prettyPrintDate()` was an imported function.