### PR TITLE
Refactor usages of forEach and single quotes in JSX

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -44,9 +44,9 @@ class App extends React.Component {
                             <Route path="/monuments/:monumentId/:slug?" component={MonumentPage}/>
                             <Route path="/search" component={SearchPage}/>
                             <Route path="/create" component={CreateMonumentPage}/>
-                            <Route path='/bulk-create' component={MonumentBulkCreatePage}/>
-                            <Route path='/tag-directory' component={TagDirectoryPage}/>
-                            <Route path='/about' component={AboutPage}/>
+                            <Route path="/bulk-create" component={MonumentBulkCreatePage}/>
+                            <Route path="/tag-directory" component={TagDirectoryPage}/>
+                            <Route path="/about" component={AboutPage}/>
                         </ErrorHandler>
                     </div>
                 </Router>

--- a/client/src/actions/monument.js
+++ b/client/src/actions/monument.js
@@ -98,9 +98,9 @@ export default function fetchMonument(id) {
             }
 
             let tagNames = [];
-            monument.monumentTags.forEach(monumentTag => {
-                tagNames.push(monumentTag.tag.name);
-            });
+            if (monument.monumentTags) {
+                tagNames = monument.monumentTags.map(monumentTag => monumentTag.tag.name);
+            }
 
             if (tagNames.length > 0) {
                 queryOptions = {

--- a/client/src/components/About/AboutInformation/AboutInformation.js
+++ b/client/src/components/About/AboutInformation/AboutInformation.js
@@ -31,7 +31,7 @@ export default class AboutInformation extends React.Component {
             <NavLink onClick={e => {
                 e.preventDefault();
                 window.location.replace('/map');
-            }} to='/map' key='map'>click here</NavLink>
+            }} to="/map" key="map">click here</NavLink>
         );
 
         const readMoreContributorsLink = (
@@ -117,7 +117,7 @@ export default class AboutInformation extends React.Component {
                     Statistics:
                 </h3>
                 <div className='statistics-container'>
-                    <div className='statistics-row'>
+                    <div className="statistics-row">
                         <StatisticCard
                             statistic={monumentStatistics.totalNumberOfMonuments}
                             description='Total number of Monuments and Memorials'
@@ -127,7 +127,7 @@ export default class AboutInformation extends React.Component {
                             description={monumentStatistics.oldestMonument
                                 ? 'Oldest Monument or Memorial on record (Date: ' + monumentStatistics.oldestMonument.date + ')'
                                 : null}
-                            statisticFontSize='small'
+                            statisticFontSize="small"
                             link={monumentStatistics.oldestMonument ? '/monuments/' + monumentStatistics.oldestMonument.id : null}
                         />
                         <StatisticCard
@@ -135,7 +135,7 @@ export default class AboutInformation extends React.Component {
                             description={monumentStatistics.newestMonument
                                 ? 'Newest Monument or Memorial on record (Date: ' + monumentStatistics.newestMonument.date + ')'
                                 : null}
-                            statisticFontSize='small'
+                            statisticFontSize="small"
                             link={monumentStatistics.newestMonument ? '/monuments/' + monumentStatistics.newestMonument.id : null}
                         />
                     </div>

--- a/client/src/components/About/AboutInformation/AboutInformation.js
+++ b/client/src/components/About/AboutInformation/AboutInformation.js
@@ -35,35 +35,35 @@ export default class AboutInformation extends React.Component {
         );
 
         const readMoreContributorsLink = (
-            <div className='more-contributors-link'
+            <div className="more-contributors-link"
                  onClick={() => this.handleMoreContributorsClick()}>
                 Read More
             </div>
         );
 
         const hideMoreContributorsLink = (
-            <div className='more-contributors-link hide-link'
+            <div className="more-contributors-link hide-link"
                  onClick={() => this.handleMoreContributorsClick()}>
                 Hide
             </div>
         );
 
         return (
-            <div className='about-information-container'>
+            <div className="about-information-container">
                 <h1>
                     About Monuments + Memorials
                 </h1>
                 {/* TODO: Replace click here with link to sign-in page */}
                 <p>
-                    <span className='font-italic'>Monuments + Memorials</span> is a crowd-sourced initiative developed at
+                    <span className="font-italic">Monuments + Memorials</span> is a crowd-sourced initiative developed at
                     the Rochester Institute of Technology under the direction of Dr. Juilee Decker. Students in her spring
-                    2019 history course <span className='font-italic'>Monuments & Memory</span> began data collection by
+                    2019 history course <span className="font-italic">Monuments & Memory</span> began data collection by
                     examining 26 states or territories in the US. The following fall, software engineering students in the
                     Golisano College of Computer and Information Sciences built this web application to house data and to
                     generate further interest and data collection. To view monuments and memorials, {mapNavLink}. To enter
                     data, click here.
                 </p>
-                <h3 className='font-italic'>
+                <h3 className="font-italic">
                     Background:
                 </h3>
                 <p>
@@ -83,7 +83,7 @@ export default class AboutInformation extends React.Component {
                     anyone to contribute information and an image of monuments and memorials in these areas. If you have
                     any questions, please contact the project coordinator, Juilee Decker jdgsh@rit.edu.
                 </p>
-                <h3 className='font-italic'>
+                <h3 className="font-italic">
                     Contributors:
                 </h3>
                 {/* TODO: Replace click here with link to sign-in page */}
@@ -92,7 +92,7 @@ export default class AboutInformation extends React.Component {
                     submissions will be recognized in our list of contributors:
                 </p>
 
-                <div className='contributors-list-container'>
+                <div className="contributors-list-container">
                     <ContributorsList
                         contributors={contributors}
                         showingAllContributors={showingAllContributors}
@@ -102,25 +102,25 @@ export default class AboutInformation extends React.Component {
                     {showingAllContributors && hideMoreContributorsLink}
                 </div>
 
-                <h3 className='font-italic'>
+                <h3 className="font-italic">
                     Acknowledgements:
                 </h3>
                 <p>
-                    <span className='font-weight-bold'>Software engineering students:</span> AJ Delposen, Nick Deyette, Ben Smith, Ben Vogler<br/>
-                    <span className='font-weight-bold'>Advisors:</span> Eric Mansfield, Samuel Malachowsky, Jim Vallino<br/>
+                    <span className="font-weight-bold">Software engineering students:</span> AJ Delposen, Nick Deyette, Ben Smith, Ben Vogler<br/>
+                    <span className="font-weight-bold">Advisors:</span> Eric Mansfield, Samuel Malachowsky, Jim Vallino<br/>
                     Lizzy Carr, research assistant<br/>
                     Connie Froass, graphic design<br/>
-                    Students in HIS 322 course, <span className='font-italic'>Monuments & Memory</span>, spring 2019 and
+                    Students in HIS 322 course, <span className="font-italic">Monuments & Memory</span>, spring 2019 and
                     spring 2020
                 </p>
-                <h3 className='font-italic'>
+                <h3 className="font-italic">
                     Statistics:
                 </h3>
-                <div className='statistics-container'>
+                <div className="statistics-container">
                     <div className="statistics-row">
                         <StatisticCard
                             statistic={monumentStatistics.totalNumberOfMonuments}
-                            description='Total number of Monuments and Memorials'
+                            description="Total number of Monuments and Memorials"
                         />
                         <StatisticCard
                             statistic={monumentStatistics.oldestMonument ? monumentStatistics.oldestMonument.title : null}
@@ -139,7 +139,7 @@ export default class AboutInformation extends React.Component {
                             link={monumentStatistics.newestMonument ? '/monuments/' + monumentStatistics.newestMonument.id : null}
                         />
                     </div>
-                    <div className='statistics-row last'>
+                    <div className="statistics-row last">
                         <StatisticCard
                             statistic={monumentStatistics.numberOfMonumentsInRandomState}
                             description={'Number of Monuments in ' + monumentStatistics.randomState}
@@ -150,7 +150,7 @@ export default class AboutInformation extends React.Component {
                         />
                     </div>
                 </div>
-                <div className='charts-container'>
+                <div className="charts-container">
                     <NumberOfMonumentsByStateBarChart
                         numberOfMonumentsByState={monumentStatistics.numberOfMonumentsByState}
                     />

--- a/client/src/components/About/AboutInformation/ContributorsList/ContributorsList.js
+++ b/client/src/components/About/AboutInformation/ContributorsList/ContributorsList.js
@@ -16,7 +16,7 @@ export default class ContributorsList extends React.Component {
 
             return (
                 <div>
-                    <div className='contributors-list-shown-container'>
+                    <div className="contributors-list-shown-container">
                         {
                             contributorsToDisplay.map((contributor) => {
                                 return <div key={contributor}>{contributor}</div>;
@@ -25,7 +25,7 @@ export default class ContributorsList extends React.Component {
                     </div>
 
                     <Collapse in={showingAllContributors}>
-                        <div className='contributors-list-hidden-container'>
+                        <div className="contributors-list-hidden-container">
                             {
                                 hiddenContributors.map((contributor) => {
                                     return <div key={contributor}>{contributor}</div>

--- a/client/src/components/About/AboutInformation/NumberOfMonumentsByStateBarChart/NumberOfMonumentsByStateBarChart.js
+++ b/client/src/components/About/AboutInformation/NumberOfMonumentsByStateBarChart/NumberOfMonumentsByStateBarChart.js
@@ -52,7 +52,7 @@ export default class NumberOfMonumentsByStateBarChart extends React.Component {
         };
 
         const chartDisplay = (
-            <div className='monuments-by-state-bar-chart-container'>
+            <div className="monuments-by-state-bar-chart-container">
                 <BarChart
                     data={chartData}
                     options={chartOptions}

--- a/client/src/components/About/AboutInformation/StatisticCard/StatisticCard.js
+++ b/client/src/components/About/AboutInformation/StatisticCard/StatisticCard.js
@@ -27,7 +27,7 @@ export default class StatisticCard extends React.Component {
 
         if (statistic && description) {
             return (
-                <div className='statistic-card-container'>
+                <div className="statistic-card-container">
                     <Card>
                         <Card.Title className={statisticFontSizeClassName}>
                             {statisticWithLink ? statisticWithLink : statistic}

--- a/client/src/components/BulkCreateForm/BulkCreateForm.js
+++ b/client/src/components/BulkCreateForm/BulkCreateForm.js
@@ -149,21 +149,21 @@ export default class BulkCreateForm extends React.Component {
         const { fileUpload, showingMoreInformation, fileUploadInputKey } = this.state;
 
         const moreInformationLink = (
-            <div className='more-information-link'
+            <div className="more-information-link"
                  onClick={() => this.handleMoreInformationClick()}>
                 Show More Information
             </div>
         );
 
         const hideMoreInformationLink = (
-            <div className='more-information-link hide-link'
+            <div className="more-information-link hide-link"
                  onClick={() => this.handleMoreInformationClick()}>
                 Hide More Information
             </div>
         );
 
         return (
-            <div className='bulk-create-form-container'>
+            <div className="bulk-create-form-container">
                 <div className="h5">
                     Bulk Create Monuments and Memorials
                 </div>
@@ -171,26 +171,26 @@ export default class BulkCreateForm extends React.Component {
                 <Form onSubmit={(event) => this.handleSubmit(event)}>
                     <Form.Group className="file-upload-form-group">
                         <Form.Label>Upload a CSV or Zip File:</Form.Label>
-                        <label htmlFor='file-upload-input' className='file-upload-input-label'>
+                        <label htmlFor="file-upload-input" className="file-upload-input-label">
                             <span>CHOOSE A FILE</span>
                         </label>
                         <Form.Control
                             type="file"
-                            id='file-upload-input'
+                            id="file-upload-input"
                             onChange={(event) => this.handleFileUploadChange(event)}
                             isInvalid={!fileUpload.isValid}
                             accept=".csv,.zip"
-                            className='file-upload-input'
+                            className="file-upload-input"
                             key={fileUploadInputKey}
                         />
-                        <Form.Control.Feedback type='invalid'>{fileUpload.errorMessage}</Form.Control.Feedback>
+                        <Form.Control.Feedback type="invalid">{fileUpload.errorMessage}</Form.Control.Feedback>
                         <div className={fileUpload.isValid ? 'file-upload-input-file-name' : 'd-none'}>
                             {fileUpload.message}
                         </div>
                     </Form.Group>
 
                     <Collapse in={showingMoreInformation}>
-                        <div className='more-information-container'>
+                        <div className="more-information-container">
                             <MoreInformation/>
                         </div>
                     </Collapse>
@@ -202,23 +202,23 @@ export default class BulkCreateForm extends React.Component {
                         <Button
                             variant="primary"
                             type="submit"
-                            className='mr-4 mt-1'
+                            className="mr-4 mt-1"
                         >
                             Submit
                         </Button>
 
                         <Button
-                            variant='secondary'
-                            type='button'
+                            variant="secondary"
+                            type="button"
                             onClick={() => this.resetForm(true)}
-                            className='mr-4 mt-1'
+                            className="mr-4 mt-1"
                         >
                             Clear
                         </Button>
 
                         <Button
-                            variant='danger'
-                            type='button'
+                            variant="danger"
+                            type="button"
                             onClick={() => this.handleCancelButtonClick()}
                             className="mt-1"
                         >
@@ -227,7 +227,7 @@ export default class BulkCreateForm extends React.Component {
                     </ButtonToolbar>
                 </Form>
 
-                <div className='feedback-modal-container'>
+                <div className="feedback-modal-container">
                     <FeedbackModal
                         bulkCreateResult={bulkCreateResult}
                         onClose={() => this.handleFeedbackModalClose()}

--- a/client/src/components/BulkCreateForm/BulkCreateForm.js
+++ b/client/src/components/BulkCreateForm/BulkCreateForm.js
@@ -164,22 +164,22 @@ export default class BulkCreateForm extends React.Component {
 
         return (
             <div className='bulk-create-form-container'>
-                <div className='h5'>
+                <div className="h5">
                     Bulk Create Monuments and Memorials
                 </div>
 
                 <Form onSubmit={(event) => this.handleSubmit(event)}>
-                    <Form.Group className='file-upload-form-group'>
+                    <Form.Group className="file-upload-form-group">
                         <Form.Label>Upload a CSV or Zip File:</Form.Label>
                         <label htmlFor='file-upload-input' className='file-upload-input-label'>
                             <span>CHOOSE A FILE</span>
                         </label>
                         <Form.Control
-                            type='file'
+                            type="file"
                             id='file-upload-input'
                             onChange={(event) => this.handleFileUploadChange(event)}
                             isInvalid={!fileUpload.isValid}
-                            accept='.csv,.zip'
+                            accept=".csv,.zip"
                             className='file-upload-input'
                             key={fileUploadInputKey}
                         />
@@ -200,8 +200,8 @@ export default class BulkCreateForm extends React.Component {
 
                     <ButtonToolbar className={showingMoreInformation ? 'button-toolbar-extra-padding' : null}>
                         <Button
-                            variant='primary'
-                            type='submit'
+                            variant="primary"
+                            type="submit"
                             className='mr-4 mt-1'
                         >
                             Submit
@@ -220,7 +220,7 @@ export default class BulkCreateForm extends React.Component {
                             variant='danger'
                             type='button'
                             onClick={() => this.handleCancelButtonClick()}
-                            className='mt-1'
+                            className="mt-1"
                         >
                             Cancel
                         </Button>

--- a/client/src/components/BulkCreateForm/FeedbackModal/FeedbackModal.js
+++ b/client/src/components/BulkCreateForm/FeedbackModal/FeedbackModal.js
@@ -58,9 +58,9 @@ export default class FeedbackModal extends React.Component {
                         <div className='row-number'>
                             <span className='font-weight-bold'>Row Number: </span>{key}
                         </div>
-                        <div className='csv-row'>
+                        <div className="csv-row">
                             <span className='font-weight-bold'>CSV Row:</span>
-                            <div className='csv-row-details'>
+                            <div className="csv-row-details">
                                 {bulkCreateResult.invalidCsvMonumentRecordsByRowNumber[key]}
                             </div>
                         </div>
@@ -103,7 +103,7 @@ export default class FeedbackModal extends React.Component {
                 </Modal.Body>
                 <Modal.Footer>
                     <Button
-                        variant='primary'
+                        variant="primary"
                         onClick={() => this.handleClose()}
                     >
                         Continue

--- a/client/src/components/BulkCreateForm/FeedbackModal/FeedbackModal.js
+++ b/client/src/components/BulkCreateForm/FeedbackModal/FeedbackModal.js
@@ -55,17 +55,17 @@ export default class FeedbackModal extends React.Component {
                         className={'invalid-csv-row-detail-container'}
                         key={key}
                     >
-                        <div className='row-number'>
-                            <span className='font-weight-bold'>Row Number: </span>{key}
+                        <div className="row-number">
+                            <span className="font-weight-bold">Row Number: </span>{key}
                         </div>
                         <div className="csv-row">
-                            <span className='font-weight-bold'>CSV Row:</span>
+                            <span className="font-weight-bold">CSV Row:</span>
                             <div className="csv-row-details">
                                 {bulkCreateResult.invalidCsvMonumentRecordsByRowNumber[key]}
                             </div>
                         </div>
-                        <div className='reasons'>
-                            <span className='font-weight-bold'>Reasons: </span>
+                        <div className="reasons">
+                            <span className="font-weight-bold">Reasons: </span>
                             <ul>
                                 {invalidReasons}
                             </ul>
@@ -76,9 +76,9 @@ export default class FeedbackModal extends React.Component {
         }
 
         const invalidCsvRowsSection = (
-            <div className='invalid-csv-rows-container'>
+            <div className="invalid-csv-rows-container">
                 <h6>Invalid CSV Row(s):</h6>
-                <div className='invalid-csv-rows-detail-container'>
+                <div className="invalid-csv-rows-detail-container">
                     {invalidCsvRowsSectionDetails}
                 </div>
             </div>

--- a/client/src/components/BulkCreateForm/MoreInformation/MoreInformation.js
+++ b/client/src/components/BulkCreateForm/MoreInformation/MoreInformation.js
@@ -38,7 +38,7 @@ export default class MoreInformation extends React.Component {
                     <div className="h7">
                         Header Row
                     </div>
-                    <div className='subsection-information'>
+                    <div className="subsection-information">
                         <p>
                             You do NOT need to have a header row in your CSV file. If you include one, an invalid record
                             will be created.
@@ -47,141 +47,141 @@ export default class MoreInformation extends React.Component {
                     <div className="h7">
                         Columns
                     </div>
-                    <div className='subsection-information'>
+                    <div className="subsection-information">
                         The order of the columns in your CSV file should be:
                         <ol>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Submitted By:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The name of the contributor who gathered the data for this Monument or Memorial
                                     record.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Artist:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The name of the artist who created the Monument or Memorial.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Title:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The title of the Monument or Memorial.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     THIS IS A REQUIRED FIELD.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Date:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The date that the Monument or Memorial was created. The format of the date must be:
                                     "dd-MM-yyyy". For example: "24-08-1999" would be August 24th, 1999. If the day and
                                     month are unknown, simply use the format: "yyyy".
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Materials:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The material that the Monument or Memorial is made out of. To include more than one
                                     Material, simply separate them with a comma.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     THIS IS A REQUIRED FIELD.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Inscription:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     Any text inscriptions that are written on the Monument or Memorial.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Latitude:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The latitude of the Monument or Memorial.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     SPECIFYING THIS FIELD AND "Longitude" OR SPECIFYING "Address" IS REQUIRED.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Longitude:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The longitude of the Monument or Memorial.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     SPECIFYING THIS FIELD AND "Latitude" OR SPECIFYING "Address" IS REQUIRED.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     City:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The city the Monument or Memorial is located in.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     State:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The state the Monument or Memorial is located in.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Address:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The address of the Monument or Memorial.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     SPECIFYING THIS FIELD OR SPECIFYING "Latitude" AND "Longitude" IS REQUIRED.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Tags:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     Any words or phrases that categorize or describe the Monument or Memorial. To
                                     include more than one Tag, simply separate them with a comma.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Reference:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     Any URL or link where more information can be found about the Monument or Memorial.
                                 </div>
                             </li>
                             <li>
-                                <div className='column-name'>
+                                <div className="column-name">
                                     Image Filename:
                                 </div>
-                                <div className='column-explanation'>
+                                <div className="column-explanation">
                                     The name of the image file that is associated with the Monument or Memorial.
                                 </div>
-                                <div className='column-explanation-notice'>
+                                <div className="column-explanation-notice">
                                     This column will only be used when a .zip file is uploaded!
                                 </div>
                             </li>

--- a/client/src/components/BulkCreateForm/MoreInformation/MoreInformation.js
+++ b/client/src/components/BulkCreateForm/MoreInformation/MoreInformation.js
@@ -35,7 +35,7 @@ export default class MoreInformation extends React.Component {
                     How do I format my CSV file?
                 </Card.Subtitle>
                 <Card.Body>
-                    <div className='h7'>
+                    <div className="h7">
                         Header Row
                     </div>
                     <div className='subsection-information'>
@@ -44,7 +44,7 @@ export default class MoreInformation extends React.Component {
                             will be created.
                         </p>
                     </div>
-                    <div className='h7'>
+                    <div className="h7">
                         Columns
                     </div>
                     <div className='subsection-information'>

--- a/client/src/components/Charts/BarChart/BarChart.js
+++ b/client/src/components/Charts/BarChart/BarChart.js
@@ -24,7 +24,7 @@ export default class BarChart extends React.Component {
 
     render() {
         return (
-            <div className='bar-chart-container'>
+            <div className="bar-chart-container">
                 <canvas
                     id="bar-chart"
                     ref={this.chartRef}

--- a/client/src/components/Charts/BarChart/BarChart.js
+++ b/client/src/components/Charts/BarChart/BarChart.js
@@ -26,7 +26,7 @@ export default class BarChart extends React.Component {
         return (
             <div className='bar-chart-container'>
                 <canvas
-                    id='bar-chart'
+                    id="bar-chart"
                     ref={this.chartRef}
                 />
             </div>

--- a/client/src/components/CreateForm/CreateForm.js
+++ b/client/src/components/CreateForm/CreateForm.js
@@ -219,14 +219,14 @@ export default class CreateForm extends React.Component {
         inscription.isValid = true;
         inscription.message = '';
 
-        references.forEach(reference => {
+        for (let reference of references) {
             reference.isValid = true;
             reference.message = '';
 
             if (resetValue) {
                 reference.value = '';
             }
-        });
+        }
 
         materials.isValid = true;
         materials.message = '';
@@ -351,7 +351,7 @@ export default class CreateForm extends React.Component {
 
         /* References Validation */
         /* Check that the References are valid URLs */
-        references.forEach(reference => {
+        for (let reference of references) {
             if (!validator.isEmpty(reference.value)) {
                 if (!validator.isURL(reference.value)) {
                     reference.isValid = false;
@@ -359,7 +359,7 @@ export default class CreateForm extends React.Component {
                     formIsValid = false;
                 }
             }
-        });
+        }
 
         if (!formIsValid) {
             this.setState({title, address, latitude, longitude, year, month, references});
@@ -519,25 +519,21 @@ export default class CreateForm extends React.Component {
                 dateInput = <div/>;
         }
 
-        const referenceInputs = [];
-
-        references.forEach((reference, index) => {
-            referenceInputs.push(
-                <div className='reference-container' key={index}>
-                    <Form.Label>Reference:</Form.Label>
-                    <Form.Control
-                        type='text'
-                        name={'reference-' + index}
-                        placeholder='Reference URL'
-                        value={reference.value}
-                        onChange={(event) => this.handleReferenceChange(event)}
-                        isInvalid={!reference.isValid}
-                        className='text-control'
-                    />
-                    <Form.Control.Feedback type='invalid'>{reference.message}</Form.Control.Feedback>
-                </div>
-            );
-        });
+        const referenceInputs = references.map((reference, index) => (
+            <div className='reference-container' key={index}>
+                <Form.Label>Reference:</Form.Label>
+                <Form.Control
+                    type='text'
+                    name={'reference-' + index}
+                    placeholder='Reference URL'
+                    value={reference.value}
+                    onChange={(event) => this.handleReferenceChange(event)}
+                    isInvalid={!reference.isValid}
+                    className='text-control'
+                />
+                <Form.Control.Feedback type='invalid'>{reference.message}</Form.Control.Feedback>
+            </div>
+        ));
 
         const invalidMaterials = (
             <div className='invalid-feedback materials'>{materials.message}</div>

--- a/client/src/components/CreateForm/CreateForm.js
+++ b/client/src/components/CreateForm/CreateForm.js
@@ -446,12 +446,12 @@ export default class CreateForm extends React.Component {
         let dateInput;
 
         const dateYearInput = (
-            <Form.Group controlId='create-form-date-year'>
+            <Form.Group controlId="create-form-date-year">
                 <Form.Label>Year:</Form.Label>
                 <Form.Control
                     type='number'
-                    name='year'
-                    placeholder='YYYY'
+                    name="year"
+                    placeholder="YYYY"
                     value={year.value}
                     onChange={(event) => this.handleInputChange(event)}
                     isInvalid={!year.isValid}
@@ -471,25 +471,25 @@ export default class CreateForm extends React.Component {
                         <Form.Group controlId='create-form-date-month'>
                             <Form.Label>Month:</Form.Label>
                             <Form.Control
-                                as='select'
+                                as="select"
                                 name='month'
                                 value={month.value}
                                 onChange={(event) => this.handleInputChange(event)}
                                 isInvalid={!month.isValid}
                                 className='select-control mr-2'
                             >
-                                <option value='0'>January</option>
-                                <option value='1'>February</option>
-                                <option value='2'>March</option>
-                                <option value='3'>April</option>
-                                <option value='4'>May</option>
-                                <option value='5'>June</option>
-                                <option value='6'>July</option>
-                                <option value='7'>August</option>
-                                <option value='8'>September</option>
-                                <option value='9'>October</option>
-                                <option value='10'>November</option>
-                                <option value='11'>December</option>
+                                <option value="0">January</option>
+                                <option value="1">February</option>
+                                <option value="2">March</option>
+                                <option value="3">April</option>
+                                <option value="4">May</option>
+                                <option value="5">June</option>
+                                <option value="6">July</option>
+                                <option value="7">August</option>
+                                <option value="8">September</option>
+                                <option value="9">October</option>
+                                <option value="10">November</option>
+                                <option value="11">December</option>
                             </Form.Control>
                             <Form.Control.Feedback type='invalid'>{month.message}</Form.Control.Feedback>
                         </Form.Group>
@@ -504,7 +504,7 @@ export default class CreateForm extends React.Component {
                 const currentDate = new Date();
 
                 dateInput = (
-                    <Form.Group controlId='create-form-datepicker'>
+                    <Form.Group controlId="create-form-datepicker">
                         <Form.Label>Choose a Date:</Form.Label>
                         <DatePicker
                             selected={datePickerCurrentDate}
@@ -523,7 +523,7 @@ export default class CreateForm extends React.Component {
             <div className='reference-container' key={index}>
                 <Form.Label>Reference:</Form.Label>
                 <Form.Control
-                    type='text'
+                    type="text"
                     name={'reference-' + index}
                     placeholder='Reference URL'
                     value={reference.value}
@@ -541,18 +541,18 @@ export default class CreateForm extends React.Component {
 
         return (
             <div className='create-form-container'>
-                <div className='h5'>
+                <div className="h5">
                     Create a new Monument or Memorial
                 </div>
 
                 <Form onSubmit={(event) => this.handleSubmit(event)}>
                     {/* Title */}
-                    <Form.Group controlId='create-form-title'>
+                    <Form.Group controlId="create-form-title">
                         <Form.Label>Title:</Form.Label>
                         <Form.Control
-                            type='text'
-                            name='title'
-                            placeholder='Title'
+                            type="text"
+                            name="title"
+                            placeholder="Title"
                             value={title.value}
                             onChange={(event) => this.handleInputChange(event)}
                             isInvalid={!title.isValid}
@@ -562,10 +562,10 @@ export default class CreateForm extends React.Component {
                     </Form.Group>
 
                     {/* Materials */}
-                    <Form.Group controlId='create-form-materials'>
+                    <Form.Group controlId="create-form-materials">
                         <Form.Label>Materials:</Form.Label>
                         <TagsSearch
-                            variant='materials'
+                            variant="materials"
                             onChange={(variant, selectedMaterials, createdMaterials) =>
                                 this.handleMaterialSelect(variant, selectedMaterials, createdMaterials)}
                             allowTagCreation={true}
@@ -579,12 +579,12 @@ export default class CreateForm extends React.Component {
                         <span className='font-weight-bold'>Please specify one of the following:</span>
 
                         {/* Address */}
-                        <Form.Group controlId='create-form-address'>
+                        <Form.Group controlId="create-form-address">
                             <Form.Label>Address:</Form.Label>
                             <Form.Control
-                                type='text'
-                                name='address'
-                                placeholder='Address'
+                                type="text"
+                                name="address"
+                                placeholder="Address"
                                 value={address.value}
                                 onChange={(event) => this.handleInputChange(event)}
                                 isInvalid={!address.isValid}
@@ -598,9 +598,9 @@ export default class CreateForm extends React.Component {
                             <Form.Label>Coordinates:</Form.Label>
                             <Form.Row>
                                 <Form.Control
-                                    type='text'
-                                    name='latitude'
-                                    placeholder='Latitude'
+                                    type="text"
+                                    name="latitude"
+                                    placeholder="Latitude"
                                     value={latitude.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!latitude.isValid}
@@ -608,7 +608,7 @@ export default class CreateForm extends React.Component {
                                 />
                                 <Form.Control.Feedback type='invalid'>{latitude.message}</Form.Control.Feedback>
                                 <Form.Control
-                                    type='text'
+                                    type="text"
                                     name='longitude'
                                     placeholder='Longitude'
                                     value={longitude.value}
@@ -622,12 +622,12 @@ export default class CreateForm extends React.Component {
                     </div>
 
                     {/* Images */}
-                    <Form.Group controlId='create-form-image'>
+                    <Form.Group controlId="create-form-image">
                         <Form.Label>Images:</Form.Label>
                         <ImageUploader
                             withIcon={false}
                             imgExtension={['.jpg', '.png']}
-                            label=''
+                            label=""
                             fileSizeError='File size is too large'
                             fileTypeError='File type is not supported'
                             withPreview={true}
@@ -640,12 +640,12 @@ export default class CreateForm extends React.Component {
                     <Collapse in={showingAdvancedInformation}>
                         <div>
                             {/* Artist */}
-                            <Form.Group controlId='create-form-artist'>
+                            <Form.Group controlId="create-form-artist">
                                 <Form.Label>Artist:</Form.Label>
                                 <Form.Control
-                                    type='text'
-                                    name='artist'
-                                    placeholder='Artist'
+                                    type="text"
+                                    name="artist"
+                                    placeholder="Artist"
                                     value={artist.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!artist.isValid}
@@ -656,16 +656,16 @@ export default class CreateForm extends React.Component {
 
                             <div className='date-container'>
                                 {/* Date */}
-                                <Form.Group controlId='create-form-date-select'>
+                                <Form.Group controlId="create-form-date-select">
                                     <Form.Label>Date:</Form.Label>
                                     <Form.Control
-                                        as='select'
+                                        as="select"
                                         className='select-control'
                                         onChange={(event) => this.handleDateSelectChange(event)}
                                     >
-                                        <option value='year'>Year</option>
+                                        <option value="year">Year</option>
                                         <option value='month-year'>Month/Year</option>
-                                        <option value='exact-date'>Exact Date</option>
+                                        <option value="exact-date">Exact Date</option>
                                     </Form.Control>
                                 </Form.Group>
 
@@ -677,8 +677,8 @@ export default class CreateForm extends React.Component {
                             <Form.Group controlId='create-form-description'>
                                 <Form.Label>Description:</Form.Label>
                                 <Form.Control
-                                    as='textarea'
-                                    rows='3'
+                                    as="textarea"
+                                    rows="3"
                                     name='description'
                                     placeholder='Description'
                                     value={description.value}
@@ -693,8 +693,8 @@ export default class CreateForm extends React.Component {
                             <Form.Group controlId='create-form-inscription'>
                                 <Form.Label>Inscription:</Form.Label>
                                 <Form.Control
-                                    as='textarea'
-                                    rows='3'
+                                    as="textarea"
+                                    rows="3"
                                     name='inscription'
                                     placeholder='Inscription'
                                     value={inscription.value}
@@ -706,10 +706,10 @@ export default class CreateForm extends React.Component {
                             </Form.Group>
 
                             {/* Tags */}
-                            <Form.Group controlId='create-form-tags'>
+                            <Form.Group controlId="create-form-tags">
                                 <Form.Label>Tags:</Form.Label>
                                 <TagsSearch
-                                    variant='tags'
+                                    variant="tags"
                                     onChange={(variant, selectedTags, createdTags) =>
                                         this.handleTagSelect(variant, selectedTags, createdTags)}
                                     allowTagCreation={true}
@@ -733,8 +733,8 @@ export default class CreateForm extends React.Component {
 
                     <ButtonToolbar>
                         <Button
-                            variant='primary'
-                            type='submit'
+                            variant="primary"
+                            type="submit"
                             className='mr-4 mt-1'
                         >
                             Submit
@@ -753,7 +753,7 @@ export default class CreateForm extends React.Component {
                             variant='danger'
                             type='button'
                             onClick={() => this.handleCancelButtonClick()}
-                            className='mt-1'
+                            className="mt-1"
                         >
                             Cancel
                         </Button>

--- a/client/src/components/CreateForm/CreateForm.js
+++ b/client/src/components/CreateForm/CreateForm.js
@@ -436,11 +436,11 @@ export default class CreateForm extends React.Component {
             materials, showingReviewModal } = this.state;
 
         const advancedInformationLink = (
-            <div className='advanced-information-link more-link' onClick={() => this.handleAdvancedInformationClick()}>Want to tell us more?</div>
+            <div className="advanced-information-link more-link" onClick={() => this.handleAdvancedInformationClick()}>Want to tell us more?</div>
         );
 
         const hideAdvancedInformationLink = (
-            <div className='advanced-information-link hide-link' onClick={() => this.handleAdvancedInformationClick()}>Hide More Information</div>
+            <div className="advanced-information-link hide-link" onClick={() => this.handleAdvancedInformationClick()}>Hide More Information</div>
         );
 
         let dateInput;
@@ -449,15 +449,15 @@ export default class CreateForm extends React.Component {
             <Form.Group controlId="create-form-date-year">
                 <Form.Label>Year:</Form.Label>
                 <Form.Control
-                    type='number'
+                    type="number"
                     name="year"
                     placeholder="YYYY"
                     value={year.value}
                     onChange={(event) => this.handleInputChange(event)}
                     isInvalid={!year.isValid}
-                    className='text-control-small'
+                    className="text-control-small"
                 />
-                <Form.Control.Feedback type='invalid'>{year.message}</Form.Control.Feedback>
+                <Form.Control.Feedback type="invalid">{year.message}</Form.Control.Feedback>
             </Form.Group>
         );
 
@@ -468,15 +468,15 @@ export default class CreateForm extends React.Component {
             case 'month-year':
                 dateInput = (
                     <Form.Row>
-                        <Form.Group controlId='create-form-date-month'>
+                        <Form.Group controlId="create-form-date-month">
                             <Form.Label>Month:</Form.Label>
                             <Form.Control
                                 as="select"
-                                name='month'
+                                name="month"
                                 value={month.value}
                                 onChange={(event) => this.handleInputChange(event)}
                                 isInvalid={!month.isValid}
-                                className='select-control mr-2'
+                                className="select-control mr-2"
                             >
                                 <option value="0">January</option>
                                 <option value="1">February</option>
@@ -491,7 +491,7 @@ export default class CreateForm extends React.Component {
                                 <option value="10">November</option>
                                 <option value="11">December</option>
                             </Form.Control>
-                            <Form.Control.Feedback type='invalid'>{month.message}</Form.Control.Feedback>
+                            <Form.Control.Feedback type="invalid">{month.message}</Form.Control.Feedback>
                         </Form.Group>
 
                         {dateYearInput}
@@ -520,27 +520,27 @@ export default class CreateForm extends React.Component {
         }
 
         const referenceInputs = references.map((reference, index) => (
-            <div className='reference-container' key={index}>
+            <div className="reference-container" key={index}>
                 <Form.Label>Reference:</Form.Label>
                 <Form.Control
                     type="text"
                     name={'reference-' + index}
-                    placeholder='Reference URL'
+                    placeholder="Reference URL"
                     value={reference.value}
                     onChange={(event) => this.handleReferenceChange(event)}
                     isInvalid={!reference.isValid}
-                    className='text-control'
+                    className="text-control"
                 />
-                <Form.Control.Feedback type='invalid'>{reference.message}</Form.Control.Feedback>
+                <Form.Control.Feedback type="invalid">{reference.message}</Form.Control.Feedback>
             </div>
         ));
 
         const invalidMaterials = (
-            <div className='invalid-feedback materials'>{materials.message}</div>
+            <div className="invalid-feedback materials">{materials.message}</div>
         );
 
         return (
-            <div className='create-form-container'>
+            <div className="create-form-container">
                 <div className="h5">
                     Create a new Monument or Memorial
                 </div>
@@ -556,9 +556,9 @@ export default class CreateForm extends React.Component {
                             value={title.value}
                             onChange={(event) => this.handleInputChange(event)}
                             isInvalid={!title.isValid}
-                            className='text-control'
+                            className="text-control"
                         />
-                        <Form.Control.Feedback type='invalid'>{title.message}</Form.Control.Feedback>
+                        <Form.Control.Feedback type="invalid">{title.message}</Form.Control.Feedback>
                     </Form.Group>
 
                     {/* Materials */}
@@ -575,8 +575,8 @@ export default class CreateForm extends React.Component {
                         {!materials.isValid && invalidMaterials}
                     </Form.Group>
 
-                    <div className='address-coordinates-container'>
-                        <span className='font-weight-bold'>Please specify one of the following:</span>
+                    <div className="address-coordinates-container">
+                        <span className="font-weight-bold">Please specify one of the following:</span>
 
                         {/* Address */}
                         <Form.Group controlId="create-form-address">
@@ -588,13 +588,13 @@ export default class CreateForm extends React.Component {
                                 value={address.value}
                                 onChange={(event) => this.handleInputChange(event)}
                                 isInvalid={!address.isValid}
-                                className='text-control'
+                                className="text-control"
                             />
-                            <Form.Control.Feedback type='invalid'>{address.message}</Form.Control.Feedback>
+                            <Form.Control.Feedback type="invalid">{address.message}</Form.Control.Feedback>
                         </Form.Group>
 
                         {/* Coordinates */}
-                        <Form.Group controlId='create-form-coordinates'>
+                        <Form.Group controlId="create-form-coordinates">
                             <Form.Label>Coordinates:</Form.Label>
                             <Form.Row>
                                 <Form.Control
@@ -604,19 +604,19 @@ export default class CreateForm extends React.Component {
                                     value={latitude.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!latitude.isValid}
-                                    className='text-control-small mr-2'
+                                    className="text-control-small mr-2"
                                 />
-                                <Form.Control.Feedback type='invalid'>{latitude.message}</Form.Control.Feedback>
+                                <Form.Control.Feedback type="invalid">{latitude.message}</Form.Control.Feedback>
                                 <Form.Control
                                     type="text"
-                                    name='longitude'
-                                    placeholder='Longitude'
+                                    name="longitude"
+                                    placeholder="Longitude"
                                     value={longitude.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!longitude.isValid}
-                                    className='text-control-small'
+                                    className="text-control-small"
                                 />
-                                <Form.Control.Feedback type='invalid'>{longitude.message}</Form.Control.Feedback>
+                                <Form.Control.Feedback type="invalid">{longitude.message}</Form.Control.Feedback>
                             </Form.Row>
                         </Form.Group>
                     </div>
@@ -628,12 +628,12 @@ export default class CreateForm extends React.Component {
                             withIcon={false}
                             imgExtension={['.jpg', '.png']}
                             label=""
-                            fileSizeError='File size is too large'
-                            fileTypeError='File type is not supported'
+                            fileSizeError="File size is too large"
+                            fileTypeError="File type is not supported"
                             withPreview={true}
                             onChange={(files) => this.handleImageUploaderChange(files)}
                             key={imageUploaderKey}
-                            errorClass='invalid-feedback'
+                            errorClass="invalid-feedback"
                         />
                     </Form.Group>
 
@@ -649,22 +649,22 @@ export default class CreateForm extends React.Component {
                                     value={artist.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!artist.isValid}
-                                    className='text-control'
+                                    className="text-control"
                                 />
-                                <Form.Control.Feedback type='invalid'>{artist.message}</Form.Control.Feedback>
+                                <Form.Control.Feedback type="invalid">{artist.message}</Form.Control.Feedback>
                             </Form.Group>
 
-                            <div className='date-container'>
+                            <div className="date-container">
                                 {/* Date */}
                                 <Form.Group controlId="create-form-date-select">
                                     <Form.Label>Date:</Form.Label>
                                     <Form.Control
                                         as="select"
-                                        className='select-control'
+                                        className="select-control"
                                         onChange={(event) => this.handleDateSelectChange(event)}
                                     >
                                         <option value="year">Year</option>
-                                        <option value='month-year'>Month/Year</option>
+                                        <option value="month-year">Month/Year</option>
                                         <option value="exact-date">Exact Date</option>
                                     </Form.Control>
                                 </Form.Group>
@@ -674,35 +674,35 @@ export default class CreateForm extends React.Component {
                             </div>
 
                             {/* Description */}
-                            <Form.Group controlId='create-form-description'>
+                            <Form.Group controlId="create-form-description">
                                 <Form.Label>Description:</Form.Label>
                                 <Form.Control
                                     as="textarea"
                                     rows="3"
-                                    name='description'
-                                    placeholder='Description'
+                                    name="description"
+                                    placeholder="Description"
                                     value={description.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!description.isValid}
-                                    className='multi-line-text-control'
+                                    className="multi-line-text-control"
                                 />
-                                <Form.Control.Feedback type='invalid'>{description.message}</Form.Control.Feedback>
+                                <Form.Control.Feedback type="invalid">{description.message}</Form.Control.Feedback>
                             </Form.Group>
 
                             {/* Inscription */}
-                            <Form.Group controlId='create-form-inscription'>
+                            <Form.Group controlId="create-form-inscription">
                                 <Form.Label>Inscription:</Form.Label>
                                 <Form.Control
                                     as="textarea"
                                     rows="3"
-                                    name='inscription'
-                                    placeholder='Inscription'
+                                    name="inscription"
+                                    placeholder="Inscription"
                                     value={inscription.value}
                                     onChange={(event) => this.handleInputChange(event)}
                                     isInvalid={!inscription.isValid}
-                                    className='multi-line-text-control'
+                                    className="multi-line-text-control"
                                 />
-                                <Form.Control.Feedback type='invalid'>{inscription.message}</Form.Control.Feedback>
+                                <Form.Control.Feedback type="invalid">{inscription.message}</Form.Control.Feedback>
                             </Form.Group>
 
                             {/* Tags */}
@@ -717,13 +717,13 @@ export default class CreateForm extends React.Component {
                                 />
                             </Form.Group>
 
-                            <div className='references-container'>
+                            <div className="references-container">
                                 {/* References */}
-                                <Form.Group controlId='create-form-references'>
+                                <Form.Group controlId="create-form-references">
                                     {referenceInputs}
                                 </Form.Group>
 
-                                <div className='add-reference-link' onClick={() => this.handleAddAnotherReferenceLinkClick()}>+ Add Another Reference</div>
+                                <div className="add-reference-link" onClick={() => this.handleAddAnotherReferenceLinkClick()}>+ Add Another Reference</div>
                             </div>
                         </div>
                     </Collapse>
@@ -735,23 +735,23 @@ export default class CreateForm extends React.Component {
                         <Button
                             variant="primary"
                             type="submit"
-                            className='mr-4 mt-1'
+                            className="mr-4 mt-1"
                         >
                             Submit
                         </Button>
 
                         <Button
-                            variant='secondary'
-                            type='button'
+                            variant="secondary"
+                            type="button"
                             onClick={() => this.resetForm(true)}
-                            className='mr-4 mt-1'
+                            className="mr-4 mt-1"
                         >
                             Clear
                         </Button>
 
                         <Button
-                            variant='danger'
-                            type='button'
+                            variant="danger"
+                            type="button"
                             onClick={() => this.handleCancelButtonClick()}
                             className="mt-1"
                         >
@@ -760,7 +760,7 @@ export default class CreateForm extends React.Component {
                     </ButtonToolbar>
                 </Form>
 
-                <div className='no-image-modal-container'>
+                <div className="no-image-modal-container">
                     <NoImageModal
                         showing={showingNoImageModal}
                         onClose={() => this.handleNoImageModalClose()}
@@ -769,7 +769,7 @@ export default class CreateForm extends React.Component {
                     />
                 </div>
 
-                <div className='review-modal-container'>
+                <div className="review-modal-container">
                     <ReviewModal
                         showing={showingReviewModal}
                         onCancel={() => this.handleReviewModalCancel()}

--- a/client/src/components/CreateForm/NoImageModal/NoImageModal.js
+++ b/client/src/components/CreateForm/NoImageModal/NoImageModal.js
@@ -16,27 +16,27 @@ export default class NoImageModal extends React.Component {
                 show={showing}
                 onHide={onClose}
             >
-                <Modal.Header closeButton className='no-image-modal'>
+                <Modal.Header closeButton className="no-image-modal">
                     <Modal.Title>No Images Uploaded</Modal.Title>
                 </Modal.Header>
-                <hr className='no-image-modal'/>
-                <Modal.Body className='no-image-modal'>
+                <hr className="no-image-modal"/>
+                <Modal.Body className="no-image-modal">
                     <p>We try our best to provide the most informative data on all of our records.</p>
                     <p>As part of this effort, we would really appreciate if you could upload an image of the record you're creating!</p>
                     <p>If you are unable to do so, no worries! It is not required.</p>
                 </Modal.Body>
-                <Modal.Footer className='no-image-modal'>
+                <Modal.Footer className="no-image-modal">
                     <Button
                         variant="primary"
                         onClick={onCancel}
-                        className='no-image-modal'
+                        className="no-image-modal"
                     >
                         Go Back
                     </Button>
                     <Button
-                        variant='danger'
+                        variant="danger"
                         onClick={onContinue}
-                        className='no-image-modal'
+                        className="no-image-modal"
                     >
                         Continue Anyway
                     </Button>

--- a/client/src/components/CreateForm/NoImageModal/NoImageModal.js
+++ b/client/src/components/CreateForm/NoImageModal/NoImageModal.js
@@ -27,7 +27,7 @@ export default class NoImageModal extends React.Component {
                 </Modal.Body>
                 <Modal.Footer className='no-image-modal'>
                     <Button
-                        variant='primary'
+                        variant="primary"
                         onClick={onCancel}
                         className='no-image-modal'
                     >

--- a/client/src/components/CreateForm/ReviewModal/ReviewModal.js
+++ b/client/src/components/CreateForm/ReviewModal/ReviewModal.js
@@ -13,7 +13,7 @@ export default class ReviewModal extends React.Component {
         const { showing, onCancel, onConfirm, form, dateSelectValue } = this.props;
 
         let date = (
-            <span className='missing-attribute'>NONE</span>
+            <span className="missing-attribute">NONE</span>
         );
         switch (dateSelectValue) {
             case 'year':
@@ -41,7 +41,7 @@ export default class ReviewModal extends React.Component {
         );
 
         let tags = (
-            <span className='missing-attribute'>NONE</span>
+            <span className="missing-attribute">NONE</span>
         );
         if (form.tags && form.tags.length) {
             tags = (
@@ -53,7 +53,7 @@ export default class ReviewModal extends React.Component {
         }
 
         let references = (
-            <span className='missing-attribute'>NONE</span>
+            <span className="missing-attribute">NONE</span>
         );
         if (form.references) {
             let referenceList = [];
@@ -74,7 +74,7 @@ export default class ReviewModal extends React.Component {
         }
 
         let images = (
-            <span className='missing-attribute'>NONE</span>
+            <span className="missing-attribute">NONE</span>
         );
         if (form.images && form.images.length) {
             images = (
@@ -99,7 +99,7 @@ export default class ReviewModal extends React.Component {
                     <p>Please review the data you entered for correctness and completeness!</p>
                     <p>*Fields marked with an asterisk are required.</p>
                     <p>**Address OR Latitude AND Longitude are required.</p>
-                    <div className='attributes-container'>
+                    <div className="attributes-container">
                         <div className="attribute">
                             <span className="attribute-label">*Title:&nbsp;</span>
                             {form.title}
@@ -107,7 +107,7 @@ export default class ReviewModal extends React.Component {
                         <div className="attribute">
                             <span className="attribute-label">Artist:&nbsp;</span>
                             {form.artist ? form.artist : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
@@ -117,31 +117,31 @@ export default class ReviewModal extends React.Component {
                         <div className="attribute">
                             <span className="attribute-label">**Address:&nbsp;</span>
                             {form.address ? form.address : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
                             <span className="attribute-label">**Latitude:&nbsp;</span>
                             {form.latitude ? form.latitude : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
                             <span className="attribute-label">**Longitude:&nbsp;</span>
                             {form.longitude ? form.longitude : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
                             <span className="attribute-label">Description:&nbsp;</span>
                             {form.description ? form.description : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
                             <span className="attribute-label">Inscription:&nbsp;</span>
                             {form.inscription ? form.inscription : (
-                                <span className='missing-attribute'>NONE</span>
+                                <span className="missing-attribute">NONE</span>
                             )}
                         </div>
                         <div className="attribute">
@@ -164,7 +164,7 @@ export default class ReviewModal extends React.Component {
                 </Modal.Body>
                 <Modal.Footer className="review-modal">
                     <Button
-                        variant='danger'
+                        variant="danger"
                         onClick={onCancel}
                     >
                         Go Back

--- a/client/src/components/CreateForm/ReviewModal/ReviewModal.js
+++ b/client/src/components/CreateForm/ReviewModal/ReviewModal.js
@@ -89,80 +89,80 @@ export default class ReviewModal extends React.Component {
                 show={showing}
                 onHide={onCancel}
             >
-                <Modal.Header className='review-modal'>
+                <Modal.Header className="review-modal">
                     <Modal.Title>
                         Review Creation
                     </Modal.Title>
                 </Modal.Header>
-                <hr className='review-modal'/>
-                <Modal.Body className='review-modal'>
+                <hr className="review-modal"/>
+                <Modal.Body className="review-modal">
                     <p>Please review the data you entered for correctness and completeness!</p>
                     <p>*Fields marked with an asterisk are required.</p>
                     <p>**Address OR Latitude AND Longitude are required.</p>
                     <div className='attributes-container'>
-                        <div className='attribute'>
-                            <span className='attribute-label'>*Title:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">*Title:&nbsp;</span>
                             {form.title}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Artist:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Artist:&nbsp;</span>
                             {form.artist ? form.artist : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Date:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Date:&nbsp;</span>
                             {date}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>**Address:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">**Address:&nbsp;</span>
                             {form.address ? form.address : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>**Latitude:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">**Latitude:&nbsp;</span>
                             {form.latitude ? form.latitude : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>**Longitude:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">**Longitude:&nbsp;</span>
                             {form.longitude ? form.longitude : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Description:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Description:&nbsp;</span>
                             {form.description ? form.description : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Inscription:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Inscription:&nbsp;</span>
                             {form.inscription ? form.inscription : (
                                 <span className='missing-attribute'>NONE</span>
                             )}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>*Materials:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">*Materials:&nbsp;</span>
                             {materials}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Tags:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Tags:&nbsp;</span>
                             {tags}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>References:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">References:&nbsp;</span>
                             {references}
                         </div>
-                        <div className='attribute'>
-                            <span className='attribute-label'>Images:&nbsp;</span>
+                        <div className="attribute">
+                            <span className="attribute-label">Images:&nbsp;</span>
                             {images}
                         </div>
                     </div>
                 </Modal.Body>
-                <Modal.Footer className='review-modal'>
+                <Modal.Footer className="review-modal">
                     <Button
                         variant='danger'
                         onClick={onCancel}
@@ -170,7 +170,7 @@ export default class ReviewModal extends React.Component {
                         Go Back
                     </Button>
                     <Button
-                        variant='primary'
+                        variant="primary"
                         onClick={onConfirm}
                     >
                         Confirm

--- a/client/src/components/Error/ErrorModal/ErrorModal.js
+++ b/client/src/components/Error/ErrorModal/ErrorModal.js
@@ -33,19 +33,19 @@ export default class ErrorModal extends React.Component {
             >
                 <Modal.Header
                     closeButton
-                    className='error-modal'
+                    className="error-modal"
                 >
                     <Modal.Title>
                         Oops! An error occurred...
                     </Modal.Title>
                 </Modal.Header>
-                <hr className='error-modal'/>
-                <Modal.Body className='error-modal'>
+                <hr className="error-modal"/>
+                <Modal.Body className="error-modal">
                     <p>An error occurred while processing your request.</p>
                     <p>Any additional information we have will be displayed below:</p>
                     {errorMessageDisplay}
                 </Modal.Body>
-                <Modal.Footer className='error-modal'>
+                <Modal.Footer className="error-modal">
                     <Button
                         variant='danger'
                         onClick={() => this.handleClose()}

--- a/client/src/components/Error/ErrorModal/ErrorModal.js
+++ b/client/src/components/Error/ErrorModal/ErrorModal.js
@@ -22,7 +22,7 @@ export default class ErrorModal extends React.Component {
 
         if (errorMessage) {
             errorMessageDisplay = (
-                <p className='font-weight-bold'>{errorMessage}</p>
+                <p className="font-weight-bold">{errorMessage}</p>
             );
         }
 
@@ -47,7 +47,7 @@ export default class ErrorModal extends React.Component {
                 </Modal.Body>
                 <Modal.Footer className="error-modal">
                     <Button
-                        variant='danger'
+                        variant="danger"
                         onClick={() => this.handleClose()}
                     >
                         Close

--- a/client/src/components/Error/ErrorScreen/ErrorScreen.js
+++ b/client/src/components/Error/ErrorScreen/ErrorScreen.js
@@ -10,7 +10,7 @@ export default class ErrorScreen extends React.Component {
         const { errors } = this.props;
 
         return (
-            <div className='error-screen-container'>
+            <div className="error-screen-container">
                 <h1>
                     Oops! An error occurred...
                 </h1>
@@ -19,7 +19,7 @@ export default class ErrorScreen extends React.Component {
                 </p>
                 {errors.map((error) => (
                     <p
-                        className='font-weight-bold'
+                        className="font-weight-bold"
                         key={error.id}
                     >
                         {error.message}

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -44,7 +44,7 @@ export default class Header extends React.Component {
             <div className="header" id="pageHeader" ref={element => this.divRef = element}>
 
                 <div className="left">
-                    <img className='header-icon' src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo"/>
+                    <img className="header-icon" src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo"/>
 
                     <div className="desktop-links">
                         <div className="links d-lg-block">
@@ -65,7 +65,7 @@ export default class Header extends React.Component {
                     {window.innerWidth < 768 && <>
                         <Modal className="mobile-search-modal" show={this.state.isSearchModalOpen} onHide={() => {this.setState({isSearchModalOpen: false})}} animation={false}>
                             <Modal.Header closeButton>
-                                <img className='header-icon' src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo" width="35px" height="35px"/>
+                                <img className="header-icon" src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo" width="35px" height="35px"/>
                             </Modal.Header>
                             <Modal.Body>
                                 <SearchBar onCloseModal={() => {

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -65,7 +65,7 @@ export default class Header extends React.Component {
                     {window.innerWidth < 768 && <>
                         <Modal className="mobile-search-modal" show={this.state.isSearchModalOpen} onHide={() => {this.setState({isSearchModalOpen: false})}} animation={false}>
                             <Modal.Header closeButton>
-                                <img className='header-icon' src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo" width='35px' height='35px'/>
+                                <img className='header-icon' src={process.env.PUBLIC_URL + '/MM-logo-rev-3.png'} alt="Monuments and Memorials Logo" width="35px" height="35px"/>
                             </Modal.Header>
                             <Modal.Body>
                                 <SearchBar onCloseModal={() => {

--- a/client/src/components/Monument/Details/About/About.js
+++ b/client/src/components/Monument/Details/About/About.js
@@ -16,7 +16,7 @@ export default class About extends React.Component {
         if (monument.title) {
             title = (
                 <div>
-                    <span className='detail-label'>Title:&nbsp;</span>
+                    <span className="detail-label">Title:&nbsp;</span>
                     {monument.title}
                 </div>
             );
@@ -26,7 +26,7 @@ export default class About extends React.Component {
         if (monument.artist) {
             artist = (
                 <div>
-                    <span className='detail-label'>Artist:&nbsp;</span>
+                    <span className="detail-label">Artist:&nbsp;</span>
                     {monument.artist}
                 </div>
             );
@@ -36,7 +36,7 @@ export default class About extends React.Component {
         if (monument.date) {
             date = (
                 <div>
-                    <span className='detail-label'>Date:&nbsp;</span>
+                    <span className="detail-label">Date:&nbsp;</span>
                     {prettyPrintDate(monument.date)}
                 </div>
             );
@@ -46,7 +46,7 @@ export default class About extends React.Component {
         if (monument.city) {
             city = (
                 <div>
-                    <span className='detail-label'>City:&nbsp;</span>
+                    <span className="detail-label">City:&nbsp;</span>
                     {monument.city}
                 </div>
             );
@@ -56,7 +56,7 @@ export default class About extends React.Component {
         if (monument.state) {
             state = (
                 <div>
-                    <span className='detail-label'>State:&nbsp;</span>
+                    <span className="detail-label">State:&nbsp;</span>
                     {monument.state}
                 </div>
             );
@@ -66,7 +66,7 @@ export default class About extends React.Component {
         if (monument.address) {
             address = (
                 <div>
-                    <span className='detail-label'>Address:&nbsp;</span>
+                    <span className="detail-label">Address:&nbsp;</span>
                     {monument.address}
                 </div>
             )
@@ -76,7 +76,7 @@ export default class About extends React.Component {
         if (monument.coordinates) {
             coordinates = (
                 <div>
-                    <span className='detail-label'>Coordinates:&nbsp;</span>
+                    <span className="detail-label">Coordinates:&nbsp;</span>
                     {monument.coordinates.coordinates[1]}, {monument.coordinates.coordinates[0]}
                 </div>
             );
@@ -86,7 +86,7 @@ export default class About extends React.Component {
         if (monument.materials && monument.materials.length) {
             materialsList = (
                 <div>
-                    <span className='detail-label'>Materials:&nbsp;</span>
+                    <span className="detail-label">Materials:&nbsp;</span>
                     <ul>
                         {monument.materials.map(material => <li key={material.id}>{material.name}</li>)}
                     </ul>
@@ -98,7 +98,7 @@ export default class About extends React.Component {
         if (monument.tags && monument.tags.length) {
             tagsList = (
                 <div>
-                    <span className='detail-label'>Tags:&nbsp;</span>
+                    <span className="detail-label">Tags:&nbsp;</span>
                     <ul>
                         {monument.tags.map(tag => <li key={tag.id}>{tag.name}</li>)}
                     </ul>
@@ -110,7 +110,7 @@ export default class About extends React.Component {
         if (monument.updatedDate) {
             lastUpdated = (
                 <div>
-                    <span className='detail-label'>Last Updated:&nbsp;</span>
+                    <span className="detail-label">Last Updated:&nbsp;</span>
                     {prettyPrintDate(monument.updatedDate)}
                 </div>
             );

--- a/client/src/components/Monument/Details/Address/Address.js
+++ b/client/src/components/Monument/Details/Address/Address.js
@@ -9,18 +9,18 @@ export default class Address extends React.Component {
     render() {
         const monument = this.props.monument;
         const locationIcon = (
-            <i className='material-icons'>room</i>
+            <i className="material-icons">room</i>
         );
 
         if (monument.address) {
             return (
-                <div style={{display: 'flex', alignItems: 'center'}} className='address-container font-italic'>
+                <div style={{display: 'flex', alignItems: 'center'}} className="address-container font-italic">
                     {locationIcon} {monument.address}
                 </div>
             )
         } else if (monument.city && monument.state) {
             return (
-                <div className='address-container font-italic'>
+                <div className="address-container font-italic">
                     {locationIcon}
                     <span className="city-state">{[monument.city, monument.state].filter(str => str && str.trim()).join(', ')}</span>
                 </div>

--- a/client/src/components/Monument/Details/Address/Address.js
+++ b/client/src/components/Monument/Details/Address/Address.js
@@ -22,7 +22,7 @@ export default class Address extends React.Component {
             return (
                 <div className='address-container font-italic'>
                     {locationIcon}
-                    <span className='city-state'>{[monument.city, monument.state].filter(str => str && str.trim()).join(', ')}</span>
+                    <span className="city-state">{[monument.city, monument.state].filter(str => str && str.trim()).join(', ')}</span>
                 </div>
             );
         }

--- a/client/src/components/Monument/Details/Details.js
+++ b/client/src/components/Monument/Details/Details.js
@@ -33,9 +33,7 @@ export default class Details extends React.Component {
 
         let tags = [];
         if (monument.monumentTags) {
-            monument.monumentTags.forEach(monumentTag => {
-                tags.push(monumentTag.tag);
-            });
+            tags = monument.monumentTags.map(monumentTag => monumentTag.tag);
         }
 
         return (

--- a/client/src/components/Search/SearchResult/SearchResult.js
+++ b/client/src/components/Search/SearchResult/SearchResult.js
@@ -17,9 +17,7 @@ export default class SearchResult extends React.Component {
 
         let tags = [];
         if (monument.monumentTags) {
-            monument.monumentTags.forEach(monumentTag => {
-                tags.push(monumentTag.tag);
-            });
+            tags = monument.monumentTags.map(monumentTag => monumentTag.tag);
         }
 
         return (

--- a/client/src/components/Search/TagsSearch/TagsSearch.js
+++ b/client/src/components/Search/TagsSearch/TagsSearch.js
@@ -78,7 +78,7 @@ class TagsSearch extends React.Component {
                         selectable
                         onSelect={(value, tag) => this.handleNewTagSelect(value, tag)}
                         tags={[tag]}
-                        selectedIcon='clear'
+                        selectedIcon="clear"
                     />
                 </div>
             );
@@ -88,7 +88,7 @@ class TagsSearch extends React.Component {
             <div className={className !== undefined ? "tags-search " + className : "tags-search"}>
                 <div className="selected-tags">
                     <Tags selectable onSelect={this.handleSelectTag.bind(this)} tags={selectedTags} selectedIcon="clear"/>
-                    <Tags selectable onSelect={this.handleNewTagSelect.bind(this)} tags={createdTags} selectedIcon='clear'/>
+                    <Tags selectable onSelect={this.handleNewTagSelect.bind(this)} tags={createdTags} selectedIcon="clear"/>
                 </div>
                 <div className="search">
                     <input type="text"

--- a/client/src/components/Search/TagsSearch/TagsSearch.js
+++ b/client/src/components/Search/TagsSearch/TagsSearch.js
@@ -72,7 +72,7 @@ class TagsSearch extends React.Component {
             };
 
             createNewTagDisplay = (
-                <div className='new-tag-container'>
+                <div className="new-tag-container">
                     <p>Create New:</p>
                     <Tags
                         selectable

--- a/client/src/pages/AboutPage/AboutPage.js
+++ b/client/src/pages/AboutPage/AboutPage.js
@@ -26,7 +26,7 @@ class AboutPage extends React.Component {
         } = this.props;
 
         return (
-            <div className='about-page-container'>
+            <div className="about-page-container">
                 <Spinner show={fetchContributorsPending || fetchMonumentStatisticsPending}/>
                 <AboutInformation
                     contributors={contributorsError ? null : contributors}

--- a/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
+++ b/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
@@ -62,12 +62,12 @@ class MonumentBulkCreatePage extends React.Component {
         const { bulkCreateMonumentsPending, bulkCreateMonumentsZipPending, result, error } = this.props;
 
         return (
-            <div className='bulk-create-page-container'>
+            <div className="bulk-create-page-container">
                 <Spinner show={bulkCreateMonumentsPending || bulkCreateMonumentsZipPending}/>
-                <div className='column thank-you-column'>
+                <div className="column thank-you-column">
                     <ContributionAppreciation/>
                 </div>
-                <div className='column form-column'>
+                <div className="column form-column">
                     <BulkCreateForm
                         onCancelButtonClick={() => this.handleBulkCreateFormCancelButtonClick()}
                         onCsvSubmit={(form) => this.handleBulkCreateCsvFormSubmit(form)}

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
@@ -29,22 +29,22 @@ class TagDirectoryPage extends React.Component {
         const allMaterials = tags.filter(tag => tag.isMaterial);
 
         return (
-            <div className='tag-directory-page-container'>
+            <div className="tag-directory-page-container">
                 <Spinner show={fetchTagsPending}/>
                 <div className="page-title">
                     <h1>
                         Tag Directory
                     </h1>
                 </div>
-                <div className='columns-container'>
-                    <div className='tags-column column'>
-                        <h2 className='font-weight-bold'>
+                <div className="columns-container">
+                    <div className="tags-column column">
+                        <h2 className="font-weight-bold">
                             Tags
                         </h2>
                         <Tags tags={allTags} selectable={false}/>
                     </div>
-                    <div className='materials-column column'>
-                        <h2 className='font-weight-bold'>
+                    <div className="materials-column column">
+                        <h2 className="font-weight-bold">
                             Materials
                         </h2>
                         <Tags tags={allMaterials} selectable={false}/>

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
@@ -31,7 +31,7 @@ class TagDirectoryPage extends React.Component {
         return (
             <div className='tag-directory-page-container'>
                 <Spinner show={fetchTagsPending}/>
-                <div className='page-title'>
+                <div className="page-title">
                     <h1>
                         Tag Directory
                     </h1>


### PR DESCRIPTION
This PR refactors all but one of our usages of `forEach` to either use `for (let member of array) {` or [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)  if applicable.

Main reason for this was to fix the error on monument pages when they have no tags, but I also replaced other usages of it that worked because they either could be done more easily with `map` or because I prefer `for of` syntax

I also replaced usages of single quotes in JSX with double quotes because it fits the HTML style better and I want us to be consistent with our usage