### PR TITLE
Add page titles

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -52,7 +52,7 @@ class App extends React.Component {
         const { headerHeight } = this.state;
         return (
             <div className="App">
-                <Helmet title={'Monuments and Memorials'}/>
+                <Helmet title="Monuments and Memorials"/>
                 <Toaster/>
                 <Router>
                     <Header onRender={headerHeight => this.setState({headerHeight})} onLogout={() => this.clearUserSession()}/>

--- a/client/src/components/Monument/Monument.js
+++ b/client/src/components/Monument/Monument.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import './Monument.scss';
-import { Helmet } from 'react-helmet';
 import Details from './Details/Details';
 import SuggestChanges from './SuggestChanges/SuggestChanges';
 import MapPhotoSphereTabs from './MapPhotoSphereTabs/MapPhotoSphereTabs';
@@ -25,7 +24,6 @@ export default class Monument extends React.Component {
 
         return (
             <div className="page-container">
-                <Helmet title={title + ' | Monuments and Memorials'}/>
                 <div className="column related-monuments-column">
                     <SuggestChanges/>
                     <RelatedMonuments title="Nearby Monuments or Memorials" monuments={nearbyMonuments} pending={fetchNearbyPending}/>

--- a/client/src/pages/AboutPage/AboutPage.js
+++ b/client/src/pages/AboutPage/AboutPage.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import AboutInformation from '../../components/About/AboutInformation/AboutInformation';
 import fetchAboutPageStatistics from '../../actions/about-page';
 import Spinner from '../../components/Spinner/Spinner';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container component for the page that contains information about the site
@@ -27,6 +28,7 @@ class AboutPage extends React.Component {
 
         return (
             <div className="about-page-container">
+                <Helmet title="About | Monuments and Memorials"/>
                 <Spinner show={fetchContributorsPending || fetchMonumentStatisticsPending}/>
                 <AboutInformation
                     contributors={contributorsError ? null : contributors}

--- a/client/src/pages/AboutPage/AboutPage.js
+++ b/client/src/pages/AboutPage/AboutPage.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import AboutInformation from '../../components/About/AboutInformation/AboutInformation';
 import fetchAboutPageStatistics from '../../actions/about-page';
 import Spinner from '../../components/Spinner/Spinner';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container component for the page that contains information about the site

--- a/client/src/pages/BeginPasswordResetPage/BeginPasswordResetPage.js
+++ b/client/src/pages/BeginPasswordResetPage/BeginPasswordResetPage.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import BeginPasswordReset from '../../components/BeginPasswordReset/BeginPasswordReset';
 import { beginPasswordReset } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class BeginPasswordResetPage extends React.Component {
 
@@ -21,6 +22,7 @@ class BeginPasswordResetPage extends React.Component {
         const { success, error, pending } = this.props;
         return (
             <div className="page d-flex justify-content-center mt-5">
+                <Helmet title="Reset Password | Monuments and Memorials"/>
                 {pending && <Spinner show={pending}/>}
                 <BeginPasswordReset onResetPassword={data => this.onSubmit(data)}
                     success={success}

--- a/client/src/pages/BeginPasswordResetPage/BeginPasswordResetPage.js
+++ b/client/src/pages/BeginPasswordResetPage/BeginPasswordResetPage.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import BeginPasswordReset from '../../components/BeginPasswordReset/BeginPasswordReset';
 import { beginPasswordReset } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class BeginPasswordResetPage extends React.Component {
 

--- a/client/src/pages/ConfirmEmailChangePage/ConfirmEmailChangePage.js
+++ b/client/src/pages/ConfirmEmailChangePage/ConfirmEmailChangePage.js
@@ -6,6 +6,7 @@ import * as QueryString from 'query-string';
 import { confirmEmailChange } from '../../actions/user';
 import { Card } from 'react-bootstrap';
 import { withRouter } from 'react-router-dom';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class ConfirmEmailChangePage extends React.Component {
 
@@ -31,6 +32,7 @@ class ConfirmEmailChangePage extends React.Component {
         const { pending, success, error } = this.props;
         return (
             <div className="change-email-confirmation page d-flex flex-column align-items-center">
+                <Helmet title="Confirm Your Email Address | Monuments and Memorials"/>
                 <Spinner show={pending}/>
                 <Card>
                     <Card.Header>

--- a/client/src/pages/ConfirmEmailChangePage/ConfirmEmailChangePage.js
+++ b/client/src/pages/ConfirmEmailChangePage/ConfirmEmailChangePage.js
@@ -6,7 +6,7 @@ import * as QueryString from 'query-string';
 import { confirmEmailChange } from '../../actions/user';
 import { Card } from 'react-bootstrap';
 import { withRouter } from 'react-router-dom';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class ConfirmEmailChangePage extends React.Component {
 

--- a/client/src/pages/ConfirmSignupPage/ConfirmSignupPage.js
+++ b/client/src/pages/ConfirmSignupPage/ConfirmSignupPage.js
@@ -6,7 +6,7 @@ import * as QueryString from 'query-string';
 import { Button, Card } from 'react-bootstrap';
 import { confirmSignup, resendConfirmation } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class ConfirmSignupPage extends React.Component {
 

--- a/client/src/pages/ConfirmSignupPage/ConfirmSignupPage.js
+++ b/client/src/pages/ConfirmSignupPage/ConfirmSignupPage.js
@@ -6,6 +6,7 @@ import * as QueryString from 'query-string';
 import { Button, Card } from 'react-bootstrap';
 import { confirmSignup, resendConfirmation } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class ConfirmSignupPage extends React.Component {
 
@@ -66,6 +67,13 @@ class ConfirmSignupPage extends React.Component {
     }
 
     render() {
+        return (<>
+            <Helmet title="Confirm Signup | Monuments and Memorials"/>
+            {this.renderPage()}
+        </>);
+    }
+
+    renderPage() {
         const { confirmSignup, resendConfirmation, session } = this.props;
         const { resend, redirect } = this.state;
 

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
@@ -8,7 +8,7 @@ import createMonument from "../../actions/create";
 import { uploadImagesToS3 } from '../../utils/api-util';
 import Spinner from "../../components/Spinner/Spinner";
 import { withRouter } from "react-router-dom";
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container for the page to create a new Monument

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
@@ -8,6 +8,7 @@ import createMonument from "../../actions/create";
 import { uploadImagesToS3 } from '../../utils/api-util';
 import Spinner from "../../components/Spinner/Spinner";
 import { withRouter } from "react-router-dom";
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container for the page to create a new Monument
@@ -41,6 +42,7 @@ class CreateMonumentPage extends React.Component {
 
         return (
             <div className="create-page-container">
+                <Helmet title="Create | Monuments and Memorials"/>
                 <Spinner show={createMonumentPending}/>
                 <div className="column thank-you-column">
                     <ContributionAppreciation/>

--- a/client/src/pages/FinishPasswordResetPage/FinishPasswordResetPage.js
+++ b/client/src/pages/FinishPasswordResetPage/FinishPasswordResetPage.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import FinishPasswordReset from '../../components/FinishPasswordReset/FinishPasswordReset';
 import { finishPasswordReset } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class FinishPasswordResetPage extends React.Component {
 

--- a/client/src/pages/FinishPasswordResetPage/FinishPasswordResetPage.js
+++ b/client/src/pages/FinishPasswordResetPage/FinishPasswordResetPage.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import FinishPasswordReset from '../../components/FinishPasswordReset/FinishPasswordReset';
 import { finishPasswordReset } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class FinishPasswordResetPage extends React.Component {
 
@@ -21,6 +22,7 @@ class FinishPasswordResetPage extends React.Component {
         const { success, error, pending } = this.props;
         return (
             <div className="page d-flex justify-content-center mt-5">
+                <Helmet title="Reset Password | Monuments and Memorials"/>
                 {pending && <Spinner show={pending}/>}
                 <FinishPasswordReset onResetPassword={data => this.onSubmit(data)}
                    success={success}

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -3,7 +3,7 @@ import './HomePage.scss';
 import SuggestChanges from '../../components/Monument/SuggestChanges/SuggestChanges';
 import { NavLink, withRouter } from 'react-router-dom';
 import { Alert } from 'react-bootstrap';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class HomePage extends React.Component {
 

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -3,6 +3,7 @@ import './HomePage.scss';
 import SuggestChanges from '../../components/Monument/SuggestChanges/SuggestChanges';
 import { NavLink, withRouter } from 'react-router-dom';
 import { Alert } from 'react-bootstrap';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class HomePage extends React.Component {
 
@@ -26,6 +27,7 @@ class HomePage extends React.Component {
 
         return (
             <>
+                <Helmet title="Monuments and Memorials"/>
                 {alert && !dismissAlert &&
                     <Alert variant="danger"
                            onClose={() => this.setState({dismissAlert: true})}

--- a/client/src/pages/LoginPage/LoginPage.js
+++ b/client/src/pages/LoginPage/LoginPage.js
@@ -5,7 +5,7 @@ import Login from '../../components/Login/Login';
 import { login } from '../../actions/authentication';
 import * as QueryString from 'query-string';
 import { withRouter, Redirect } from 'react-router-dom';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class LoginPage extends React.Component {
 

--- a/client/src/pages/LoginPage/LoginPage.js
+++ b/client/src/pages/LoginPage/LoginPage.js
@@ -5,6 +5,7 @@ import Login from '../../components/Login/Login';
 import { login } from '../../actions/authentication';
 import * as QueryString from 'query-string';
 import { withRouter, Redirect } from 'react-router-dom';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class LoginPage extends React.Component {
 
@@ -36,6 +37,7 @@ class LoginPage extends React.Component {
         }
         return (
             <div className="page d-flex justify-content-center mt-5">
+                <Helmet title="Login | Monuments and Memorials"/>
                 <Login onLogin={data => this.onLogin(data)}
                        result={result}
                        error={error && error.message}

--- a/client/src/pages/MapPage/MapPage.js
+++ b/client/src/pages/MapPage/MapPage.js
@@ -3,6 +3,7 @@ import './MapPage.scss';
 import MapResults from '../../components/Search/MapResults/MapResults';
 import { connect } from 'react-redux';
 import fetchMonuments from '../../actions/map';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class MapPage extends React.Component {
 
@@ -36,6 +37,7 @@ class MapPage extends React.Component {
         const { monuments } = this.props;
         return (
             <div className="map-page">
+                <Helmet title="Map | Monuments and Memorials"/>
                 <MapResults monuments={monuments} useCircleMarkers zoom={this.state.zoomSize}/>
             </div>
         );

--- a/client/src/pages/MapPage/MapPage.js
+++ b/client/src/pages/MapPage/MapPage.js
@@ -3,7 +3,7 @@ import './MapPage.scss';
 import MapResults from '../../components/Search/MapResults/MapResults';
 import { connect } from 'react-redux';
 import fetchMonuments from '../../actions/map';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class MapPage extends React.Component {
 

--- a/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
+++ b/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
@@ -7,6 +7,7 @@ import { bulkValidateMonuments, bulkCreateMonuments } from '../../actions/bulk';
 import Spinner from '../../components/Spinner/Spinner';
 import ErrorModal from '../../components/Error/ErrorModal/ErrorModal';
 import { Modal, ProgressBar } from 'react-bootstrap';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container for the page to bulk create Monuments
@@ -65,6 +66,7 @@ class MonumentBulkCreatePage extends React.Component {
 
         return (
             <div className="page d-flex justify-content-center">
+                <Helmet title="Bulk Create | Monuments and Memorials"/>
                 <Spinner show={bulkValidateMonumentsPending}/>
                 <BulkCreateForm
                     onValidationSubmit={(form) => this.handleValidationSubmit(form)}

--- a/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
+++ b/client/src/pages/MonumentBulkCreatePage/MonumentBulkCreatePage.js
@@ -7,7 +7,7 @@ import { bulkValidateMonuments, bulkCreateMonuments } from '../../actions/bulk';
 import Spinner from '../../components/Spinner/Spinner';
 import ErrorModal from '../../components/Error/ErrorModal/ErrorModal';
 import { Modal, ProgressBar } from 'react-bootstrap';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container for the page to bulk create Monuments

--- a/client/src/pages/MonumentPage/MonumentPage.js
+++ b/client/src/pages/MonumentPage/MonumentPage.js
@@ -6,6 +6,7 @@ import Monument from '../../components/Monument/Monument';
 import Spinner from '../../components/Spinner/Spinner';
 import fetchMonument from '../../actions/monument';
 import * as slugify from 'slugify';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container component for the monument record page which handles retrieving the monument
@@ -49,6 +50,7 @@ class MonumentPage extends React.Component {
         } = this.props;
         return (
             <div className="page h-100">
+                {monument && <Helmet title={monument.title + ' | Monuments and Memorials'}/>}
                 <Spinner show={fetchMonumentPending}/>
                 <Monument monument={monument} nearbyMonuments={nearbyMonuments} relatedMonuments={relatedMonuments}
                           fetchNearbyPending={fetchNearbyPending} fetchRelatedPending={fetchRelatedPending}/>

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -5,6 +5,7 @@ import Spinner from '../../components/Spinner/Spinner';
 import Search from '../../components/Search/Search';
 import * as QueryString from 'query-string';
 import search from '../../utils/search';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container component for the search page which handles retrieving the search results
@@ -49,6 +50,7 @@ class SearchPage extends React.Component {
         const { monuments, count, pending } = this.props;
         return (
             <div className="h-100">
+                <Helmet title="Search | Monuments and Memorials"/>
                 <Spinner show={pending}/>
                 <Search monuments={monuments} {...this.getQueryParams()} count={count}
                         onLimitChange={this.handleLimitChange.bind(this)} onPageChange={this.handlePageChange.bind(this)}

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -5,7 +5,7 @@ import Spinner from '../../components/Spinner/Spinner';
 import Search from '../../components/Search/Search';
 import * as QueryString from 'query-string';
 import search from '../../utils/search';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container component for the search page which handles retrieving the search results

--- a/client/src/pages/SignupPage/SignupPage.js
+++ b/client/src/pages/SignupPage/SignupPage.js
@@ -5,7 +5,7 @@ import Signup from '../../components/Signup/Signup';
 import { signup } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
 import { withRouter } from 'react-router-dom';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class SignupPage extends React.Component {
 

--- a/client/src/pages/SignupPage/SignupPage.js
+++ b/client/src/pages/SignupPage/SignupPage.js
@@ -5,6 +5,7 @@ import Signup from '../../components/Signup/Signup';
 import { signup } from '../../actions/authentication';
 import Spinner from '../../components/Spinner/Spinner';
 import { withRouter } from 'react-router-dom';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class SignupPage extends React.Component {
 
@@ -21,6 +22,7 @@ class SignupPage extends React.Component {
         const { pending, error, result } = this.props;
         return (
             <div className="page d-flex justify-content-center mt-5">
+                <Helmet title="Signup | Monuments and Memorials"/>
                 <Spinner show={pending}/>
                 <Signup onSignup={data => this.signup(data)} error={error && error.message} result={result}/>
             </div>

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
@@ -4,7 +4,7 @@ import fetchTags from '../../actions/tagDirectory';
 import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import Tags from "../../components/Tags/Tags";
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container component for the Tag Directory Page

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
@@ -4,6 +4,7 @@ import fetchTags from '../../actions/tagDirectory';
 import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import Tags from "../../components/Tags/Tags";
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container component for the Tag Directory Page
@@ -30,6 +31,7 @@ class TagDirectoryPage extends React.Component {
 
         return (
             <div className="tag-directory-page-container">
+                <Helmet title="Tags and Materials | Monuments and Memorials"/>
                 <Spinner show={fetchTagsPending}/>
                 <div className="page-title">
                     <h1>

--- a/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
+++ b/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
@@ -7,7 +7,7 @@ import CreateOrUpdateForm from '../../components/CreateOrUpdateForm/CreateOrUpda
 import Spinner from '../../components/Spinner/Spinner';
 import ContributionAppreciation from '../../components/ContributionAppreciation/ContributionAppreciation';
 import { uploadImagesToS3, deleteImagesFromS3 } from '../../utils/api-util';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 /**
  * Root container for the page to update an existing Monument

--- a/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
+++ b/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
@@ -7,6 +7,7 @@ import CreateOrUpdateForm from '../../components/CreateOrUpdateForm/CreateOrUpda
 import Spinner from '../../components/Spinner/Spinner';
 import ContributionAppreciation from '../../components/ContributionAppreciation/ContributionAppreciation';
 import { uploadImagesToS3, deleteImagesFromS3 } from '../../utils/api-util';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 /**
  * Root container for the page to update an existing Monument
@@ -48,6 +49,7 @@ class UpdateMonumentPage extends React.Component {
 
         return (
             <div className="update-monument-page-container">
+                {monument && <Helmet title={`Update ${monument.title} | Monuments and Memorials`}/>}
                 <Spinner show={fetchMonumentForUpdatePending || updateMonumentPending}/>
                 <div className="column thank-you-column">
                     <ContributionAppreciation/>

--- a/client/src/pages/UpdateUserPage/UpdateUserPage.js
+++ b/client/src/pages/UpdateUserPage/UpdateUserPage.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import UpdateUser from '../../components/UpdateUser/UpdateUser';
 import { updateUser, clearUpdateUser } from '../../actions/user';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class UpdateUserPage extends React.Component {
 

--- a/client/src/pages/UpdateUserPage/UpdateUserPage.js
+++ b/client/src/pages/UpdateUserPage/UpdateUserPage.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import UpdateUser from '../../components/UpdateUser/UpdateUser';
 import { updateUser, clearUpdateUser } from '../../actions/user';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class UpdateUserPage extends React.Component {
 
@@ -31,6 +32,7 @@ class UpdateUserPage extends React.Component {
         const { pending, success, error, needsConfirmation, session } = this.props;
         return (
             <div className="update-user page">
+                <Helmet title="Update Your Information | Monuments and Memorials"/>
                 <Spinner show={session.pending || pending}/>
                 {session.user &&
                     <UpdateUser user={session.user} success={success} error={error}

--- a/client/src/pages/UserPage/UserPage.js
+++ b/client/src/pages/UserPage/UserPage.js
@@ -3,6 +3,7 @@ import './UserPage.scss';
 import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import User from '../../components/User/User';
+import { Helmet } from 'react-helmet/es/Helmet';
 
 class UserPage extends React.Component {
 
@@ -16,6 +17,7 @@ class UserPage extends React.Component {
         const { session } = this.props;
         return (
             <div className="account page">
+                <Helmet title="Account | Monuments and Memorials"/>
                 <Spinner show={session.pending}/>
                 {session.user &&
                     <User user={session.user}/>

--- a/client/src/pages/UserPage/UserPage.js
+++ b/client/src/pages/UserPage/UserPage.js
@@ -3,7 +3,7 @@ import './UserPage.scss';
 import { connect } from 'react-redux';
 import Spinner from '../../components/Spinner/Spinner';
 import User from '../../components/User/User';
-import { Helmet } from 'react-helmet/es/Helmet';
+import { Helmet } from 'react-helmet';
 
 class UserPage extends React.Component {
 


### PR DESCRIPTION
This is a quick PR that adds unique page titles to most pages, instead of using `Monuments and Memorials` everywhere. I also moved the `Helmet` for the monument page up from `Monument.js` to `MonumentPage.js`, as I think we should always do this from page files

Going forward please be sure to include a `<Helmet>` tag in your `pages/...` components so that we have good page titles! @njd9419 @bxsmith007 