### PR TITLE
LastModifiedBy/CreatedBy implementation and tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('junit:junit:4.12')
     testImplementation('org.mockito:mockito-core:2.13.0')
+    testImplementation('org.springframework.security:spring-security-test')
 }
 
 node {

--- a/src/main/java/com/monumental/config/JpaAuditConfiguration.java
+++ b/src/main/java/com/monumental/config/JpaAuditConfiguration.java
@@ -1,0 +1,31 @@
+package com.monumental.config;
+
+import com.monumental.exceptions.UnauthorizedException;
+import com.monumental.models.User;
+import com.monumental.services.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * This class is responsible for retrieving the User record that will be set on createdBy and lastModifiedBy in Models
+ */
+@Component
+public class JpaAuditConfiguration implements AuditorAware<User> {
+
+    @Autowired
+    private UserService userService;
+
+    @Override
+    public Optional<User> getCurrentAuditor() {
+        if (SecurityContextHolder.getContext().getAuthentication() == null) return Optional.empty();
+        try {
+            return Optional.of(this.userService.getCurrentUser());
+        } catch (UnauthorizedException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/monumental/controllers/MonumentController.java
+++ b/src/main/java/com/monumental/controllers/MonumentController.java
@@ -17,6 +17,7 @@ import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class MonumentController {
      * @return Monument - The created Monument
      */
     @PostMapping("/api/monument")
+    @Transactional
     public Monument createMonument(@RequestBody CreateMonumentRequest monumentRequest) {
         return this.monumentService.createMonument(monumentRequest);
     }

--- a/src/main/java/com/monumental/models/Model.java
+++ b/src/main/java/com/monumental/models/Model.java
@@ -43,12 +43,12 @@ public abstract class Model {
     private Date lastModifiedDate;
 
     @CreatedBy
-    @Column(name = "created_by_user_id")
-    private Integer createdByUserId;
+    @ManyToOne
+    private User createdBy;
 
     @LastModifiedBy
-    @Column(name = "last_modified_by_user_id")
-    private Integer lastModifiedByUserId;
+    @ManyToOne
+    private User lastModifiedBy;
 
     public Integer getId() {
         return this.id;
@@ -62,15 +62,31 @@ public abstract class Model {
         return this.createdDate;
     }
 
+    public void setCreatedDate(Date date) {
+        this.createdDate = date;
+    }
+
     public Date getLastModifiedDate() {
         return this.lastModifiedDate;
     }
 
-    public Integer getCreatedByUserId() {
-        return this.createdByUserId;
+    public void setLastModifiedDate(Date date) {
+        this.lastModifiedDate = date;
     }
 
-    public Integer getLastModifiedByUserId() {
-        return this.lastModifiedByUserId;
+    public User getCreatedBy() {
+        return this.createdBy;
+    }
+
+    public void setCreatedBy(User user) {
+        this.createdBy = user;
+    }
+
+    public User getLastModifiedBy() {
+        return this.lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(User user) {
+        this.lastModifiedBy = user;
     }
 }

--- a/src/main/java/com/monumental/security/SecurityConfig.java
+++ b/src/main/java/com/monumental/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private DataSource dataSource;
 
     @Autowired
-    private UserDetailServiceImpl userDetailService;
+    private UserDetailsServiceImpl userDetailsService;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -94,6 +94,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(this.userDetailService).passwordEncoder(passwordEncoder());
+        auth.userDetailsService(this.userDetailsService).passwordEncoder(passwordEncoder());
     }
 }

--- a/src/main/java/com/monumental/security/UserAwareUserDetails.java
+++ b/src/main/java/com/monumental/security/UserAwareUserDetails.java
@@ -1,0 +1,65 @@
+package com.monumental.security;
+
+import com.monumental.models.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * This class wraps the standard UserDetails interface, allowing us to store our own User model within the session object
+ */
+public class UserAwareUserDetails implements UserDetails {
+
+    private final User user;
+    private final Collection<? extends GrantedAuthority> grantedAuthorities;
+
+    public UserAwareUserDetails(User user) {
+        this(user, new ArrayList<GrantedAuthority>());
+    }
+
+    public UserAwareUserDetails(User user, Collection<? extends GrantedAuthority> grantedAuthorities) {
+        this.user = user;
+        this.grantedAuthorities = grantedAuthorities;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.grantedAuthorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return this.user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.user.getIsEnabled();
+    }
+
+    public User getUser() {
+        return this.user;
+    }
+}

--- a/src/main/java/com/monumental/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/monumental/security/UserDetailsServiceImpl.java
@@ -10,13 +10,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserDetailServiceImpl implements UserDetailsService {
-    private final UserRepository repository;
+public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Autowired
-    public UserDetailServiceImpl(UserRepository repository) {
-        this.repository = repository;
-    }
+    private UserRepository repository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -24,11 +21,7 @@ public class UserDetailServiceImpl implements UserDetailsService {
 
         if (user == null) throw new UsernameNotFoundException("Invalid email or password.");
 
-        return new org.springframework.security.core.userdetails.User(
-            username, user.getPassword(), user.getIsEnabled(),
-            true, true, true,
-            AuthorityUtils.createAuthorityList(user.getRole().toString())
-        );
+        return new UserAwareUserDetails(user, AuthorityUtils.createAuthorityList(user.getRole().toString()));
     }
 
 }

--- a/src/test/java/com/monumental/services/integrationtest/AuditingIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/AuditingIntegrationTests.java
@@ -1,0 +1,113 @@
+package com.monumental.services.integrationtest;
+
+import com.monumental.controllers.helpers.CreateMonumentRequest;
+import com.monumental.controllers.helpers.UpdateMonumentRequest;
+import com.monumental.models.Monument;
+import com.monumental.repositories.UserRepository;
+import com.monumental.security.UserAwareUserDetails;
+import com.monumental.services.MonumentService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+import org.springframework.test.context.web.ServletTestExecutionListener;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static com.monumental.services.integrationtest.UserServiceIntegrationTests.*;
+
+/**
+ * This is a unique integration test, not specifically linked to any service, but it uses MonumentService as a concrete
+ * implementation of ModelService in order to test the auditing features of Model
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@TestExecutionListeners(listeners={ServletTestExecutionListener.class,
+        DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class,
+        TransactionalTestExecutionListener.class,
+        WithSecurityContextTestExecutionListener.class})
+@SpringBootTest
+@Transactional
+public class AuditingIntegrationTests {
+
+    @Autowired
+    private MonumentService monumentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @PostConstruct
+    public void setup() {
+        createUsers(this.userRepository);
+    }
+
+    private Monument createMonument() {
+        CreateMonumentRequest request = new CreateMonumentRequest();
+        request.setTitle("Title");
+        return this.monumentService.createMonument(request);
+    }
+
+    private Monument updateMonument(Monument monument) {
+        UpdateMonumentRequest request = new UpdateMonumentRequest();
+        request.setNewTitle("New Title");
+        return this.monumentService.updateMonument(monument.getId(), request);
+    }
+
+    @Test
+    @WithUserDetails(RESEARCHER)
+    public void createMonument_correctCreatedDate() {
+        Monument monument = createMonument();
+        assertNotNull(monument.getCreatedDate());
+        // Check that the timestamp is close enough - this is a 1m window, should not cause any transient errors
+        assertTrue(new Date().getTime() - monument.getCreatedDate().getTime() < 60000);
+    }
+
+    @Test
+    @WithUserDetails(RESEARCHER)
+    public void createMonument_correctCreatedBy() {
+        Monument monument = createMonument();
+        assertNotNull(monument.getCreatedBy());
+        assertEquals(RESEARCHER, monument.getCreatedBy().getEmail());
+        assertEquals(RESEARCHER, monument.getLastModifiedBy().getEmail());
+    }
+
+    @Test
+    @WithUserDetails(RESEARCHER)
+    public void updateMonument_correctLastModifiedDate() {
+        Monument monument = createMonument();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                new UserAwareUserDetails(partner), password
+        ));
+        monument = updateMonument(monument);
+        assertNotNull(monument.getLastModifiedDate());
+        assertTrue(monument.getLastModifiedDate().getTime() > monument.getCreatedDate().getTime());
+    }
+
+    @Test
+    @WithUserDetails(RESEARCHER)
+    public void updateMonument_correctLastModifiedBy() {
+        Monument monument = createMonument();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+            new UserAwareUserDetails(partner), password
+        ));
+        monument = updateMonument(monument);
+        assertNotNull(monument.getLastModifiedBy());
+        assertEquals(PARTNER, monument.getLastModifiedBy().getEmail());
+        assertEquals(RESEARCHER, monument.getCreatedBy().getEmail());
+    }
+}

--- a/src/test/java/com/monumental/services/integrationtest/UserServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/UserServiceIntegrationTests.java
@@ -1,0 +1,98 @@
+package com.monumental.services.integrationtest;
+
+import com.monumental.models.User;
+import com.monumental.repositories.UserRepository;
+import com.monumental.security.Role;
+import com.monumental.services.UserService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+import org.springframework.test.context.web.ServletTestExecutionListener;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@TestExecutionListeners(listeners={ServletTestExecutionListener.class,
+        DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class,
+        TransactionalTestExecutionListener.class,
+        WithSecurityContextTestExecutionListener.class})
+@SpringBootTest
+public class UserServiceIntegrationTests {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public static final String RESEARCHER = "researcher@monuments.us.org";
+    public static final String PARTNER = "partner@monuments.us.org";
+    public static final String COLLABORATOR = "collaborator@monuments.us.org";
+    public static final User researcher = new User();
+    public static final User partner = new User();
+    public static final User collaborator = new User();
+    public static final String password = "password";
+
+    // This uses @PostConstruct instead of @Before so that it runs before the @WithUserDetails annotations do
+    // See this answer: https://stackoverflow.com/a/56803892/10044594
+    @PostConstruct
+    public void setup() {
+        createUsers(this.userRepository);
+    }
+
+    public static void createUsers(UserRepository userRepository) {
+        researcher.setEmail(RESEARCHER);
+        researcher.setRole(Role.RESEARCHER);
+
+        partner.setEmail(PARTNER);
+        partner.setRole(Role.PARTNER);
+
+        collaborator.setEmail(COLLABORATOR);
+        collaborator.setRole(Role.COLLABORATOR);
+
+        for (User user : Arrays.asList(researcher, partner, collaborator)) {
+            user.setFirstName("Test");
+            user.setLastName("Test");
+            user.setPassword(password);
+            userRepository.save(user);
+        }
+    }
+
+    @Test
+    @WithUserDetails(RESEARCHER)
+    public void getCurrentUser_researcher() {
+        User user = this.userService.getCurrentUser();
+        assertEquals(RESEARCHER, user.getEmail());
+        assertEquals(Role.RESEARCHER, user.getRole());
+    }
+
+    @Test
+    @WithUserDetails(PARTNER)
+    public void getCurrentUser_partner() {
+        User user = this.userService.getCurrentUser();
+        assertEquals(PARTNER, user.getEmail());
+        assertEquals(Role.PARTNER, user.getRole());
+    }
+
+    @Test
+    @WithUserDetails(COLLABORATOR)
+    public void getCurrentUser_collaborator() {
+        User user = this.userService.getCurrentUser();
+        assertEquals(COLLABORATOR, user.getEmail());
+        assertEquals(Role.COLLABORATOR, user.getRole());
+    }
+}


### PR DESCRIPTION
This is like part 1/4 for the auditing changes that will come in Milestone 8. This one implements the `lastModifiedBy` and `createdBy` so that they're automatically filled in using the session user, if one exists. It also tweaks some of the session handling so that we can get our `User` object without having to do any JPA queries and adds two new test files:

`UserServiceIntegrationTests`, which basically is meant to test that the way I'm running as a certain user within the tests works

`AuditingIntegrationTests`, which is kind of a weird one that doesn't relate to any specific service/model/repository, instead it tests the `AuditingEntityListener` on the `Model` class and checks that `createdDate`/`createdBy`/`lastModifiedDate`/`lastModifiedBy` are all updated appropriately.

The next step for auditing will probably be to see if there's a standard way to have a table of audit logs so that we can display all changes in the admin panel rather than just most recent.