### PR TITLE
Map tweaks

### DIFF
--- a/client/src/components/Search/MapResults/MapResults.js
+++ b/client/src/components/Search/MapResults/MapResults.js
@@ -21,6 +21,10 @@ export default class MapResults extends React.Component {
         };
         for (let monument of monuments.filter(monument => monument.lat && monument.lon)) {
 
+            // For any monuments with a positive longitude, move them 360 degrees west so that they render closer to
+            // the United States. This is an issue in particular with Guam because monuments there would render
+            // all the way across the map to the East, instead of in the Pacific to the West like Hawaii which
+            // made them difficult to view
             if (monument.lon > 0) monument.lon = monument.lon - 360;
 
             if (bounds.north === null || bounds.north > monument.lat) bounds.north = monument.lat;

--- a/client/src/components/Search/MapResults/MapResults.js
+++ b/client/src/components/Search/MapResults/MapResults.js
@@ -21,6 +21,8 @@ export default class MapResults extends React.Component {
         };
         for (let monument of monuments.filter(monument => monument.lat && monument.lon)) {
 
+            if (monument.lon > 0) monument.lon = monument.lon - 360;
+
             if (bounds.north === null || bounds.north > monument.lat) bounds.north = monument.lat;
             if (bounds.east === null || bounds.east < monument.lon) bounds.east = monument.lon;
             if (bounds.south === null || bounds.south < monument.lat) bounds.south = monument.lat;

--- a/client/src/pages/MapPage/MapPage.js
+++ b/client/src/pages/MapPage/MapPage.js
@@ -4,6 +4,7 @@ import MapResults from '../../components/Search/MapResults/MapResults';
 import { connect } from 'react-redux';
 import fetchMonuments from '../../actions/map';
 import { Helmet } from 'react-helmet';
+import Spinner from '../../components/Spinner/Spinner';
 
 class MapPage extends React.Component {
 
@@ -34,10 +35,11 @@ class MapPage extends React.Component {
     }
 
     render() {
-        const { monuments } = this.props;
+        const { monuments, pending } = this.props;
         return (
             <div className="map-page">
                 <Helmet title="Map | Monuments and Memorials"/>
+                <Spinner show={pending}/>
                 <MapResults monuments={monuments} useCircleMarkers zoom={this.state.zoomSize}/>
             </div>
         );


### PR DESCRIPTION
Really quick PR to:
1. Fix monuments in Guam rendering way to the East
2. Add a spinner to the Map page, since it's already a little sluggish and it's not clear why there's no pins right away

It might be worth considering a paginated approach to fetching all monuments instead of getting them in a single request. I.e., in pages of 1000 or something, go and get monuments, until out of pages, so that if there's 20,000 monuments it doesn't take 2 minutes for pins to begin showing up