### PR TITLE
Fix JPA Auditing causing transaction rollbacks

### DIFF
--- a/src/main/java/com/monumental/config/JpaAuditConfiguration.java
+++ b/src/main/java/com/monumental/config/JpaAuditConfiguration.java
@@ -23,7 +23,9 @@ public class JpaAuditConfiguration implements AuditorAware<User> {
     public Optional<User> getCurrentAuditor() {
         if (SecurityContextHolder.getContext().getAuthentication() == null) return Optional.empty();
         try {
-            return Optional.of(this.userService.getCurrentUser());
+            User user = this.userService.getCurrentUserSafely();
+            if (user == null) return Optional.empty();
+            return Optional.of(user);
         } catch (UnauthorizedException e) {
             return Optional.empty();
         }

--- a/src/main/java/com/monumental/config/JpaAuditConfiguration.java
+++ b/src/main/java/com/monumental/config/JpaAuditConfiguration.java
@@ -23,9 +23,7 @@ public class JpaAuditConfiguration implements AuditorAware<User> {
     public Optional<User> getCurrentAuditor() {
         if (SecurityContextHolder.getContext().getAuthentication() == null) return Optional.empty();
         try {
-            User user = this.userService.getCurrentUserSafely();
-            if (user == null) return Optional.empty();
-            return Optional.of(user);
+            return Optional.of(this.userService.getCurrentUser());
         } catch (UnauthorizedException e) {
             return Optional.empty();
         }

--- a/src/main/java/com/monumental/controllers/FavoriteController.java
+++ b/src/main/java/com/monumental/controllers/FavoriteController.java
@@ -43,14 +43,14 @@ public class FavoriteController {
 
     @GetMapping("/api/favorites")
     @PreAuthorize(Authentication.isAuthenticated)
-    public List<Favorite> getUserFavorites() {
+    public List<Favorite> getUserFavorites() throws UnauthorizedException {
         return this.favoriteService.getUserFavorites();
     }
 
     @GetMapping("/api/favorites/{userId}")
     @PreAuthorize(Authorization.isPartnerOrAbove)
     public List<Favorite> getUserFavorites(@PathVariable(value = "userId", required = false) Integer userId)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, UnauthorizedException {
         return this.favoriteService.getUserFavorites(userId);
     }
 
@@ -61,14 +61,14 @@ public class FavoriteController {
 
     @PostMapping("/api/favorite")
     @PreAuthorize(Authentication.isAuthenticated)
-    public Favorite createFavorite(@RequestBody FavoriteRequest request) {
+    public Favorite createFavorite(@RequestBody FavoriteRequest request) throws UnauthorizedException {
         return this.favoriteService.createFavorite(request.monumentId, request.userId);
     }
 
     @DeleteMapping("/api/favorite")
     @PreAuthorize(Authentication.isAuthenticated)
     public Map<String, Boolean> deleteFavorite(@RequestBody FavoriteRequest request)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, UnauthorizedException {
         this.favoriteService.deleteFavorite(request.monumentId, request.userId);
         return Map.of("success", true);
     }

--- a/src/main/java/com/monumental/controllers/UserController.java
+++ b/src/main/java/com/monumental/controllers/UserController.java
@@ -40,6 +40,7 @@ public class UserController {
     PasswordEncoder passwordEncoder;
 
     @PostMapping("/api/signup")
+    @Transactional
     public User signup(@RequestBody CreateUserRequest user) throws InvalidEmailOrPasswordException {
         return this.userService.signup(user);
     }

--- a/src/main/java/com/monumental/exceptions/InvalidEmailOrPasswordException.java
+++ b/src/main/java/com/monumental/exceptions/InvalidEmailOrPasswordException.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
  * Exception class used for failed login attempts (401)
  */
 @ExceptionMapping(statusCode = HttpStatus.UNAUTHORIZED, errorCode = "resource.not_found")
-public class InvalidEmailOrPasswordException extends RuntimeException {
+public class InvalidEmailOrPasswordException extends Exception {
 
     public InvalidEmailOrPasswordException() {
 

--- a/src/main/java/com/monumental/exceptions/UnauthorizedException.java
+++ b/src/main/java/com/monumental/exceptions/UnauthorizedException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
-public class UnauthorizedException extends RuntimeException {
+public class UnauthorizedException extends Exception {
 
     public UnauthorizedException() {
 

--- a/src/main/java/com/monumental/security/SecurityConfig.java
+++ b/src/main/java/com/monumental/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.monumental.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.monumental.exceptions.InvalidEmailOrPasswordException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,12 +44,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     @Override
                     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
                         // Prevent redirect attempt after successfully logging in
-                        System.out.println();
                     }
                 })
                 .failureHandler(new AuthenticationFailureHandler() {
                     @Override
-                    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws InvalidEmailOrPasswordException, IOException {
+                    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
                         // Prevent redirect attempt after failing to log in
                         response.setStatus(HttpStatus.FORBIDDEN.value());
                         Map<String, Object> data = new HashMap<>();

--- a/src/main/java/com/monumental/services/FavoriteService.java
+++ b/src/main/java/com/monumental/services/FavoriteService.java
@@ -1,6 +1,7 @@
 package com.monumental.services;
 
 import com.monumental.exceptions.ResourceNotFoundException;
+import com.monumental.exceptions.UnauthorizedException;
 import com.monumental.models.Favorite;
 import com.monumental.models.User;
 import com.monumental.repositories.FavoriteRepository;
@@ -37,8 +38,10 @@ public class FavoriteService {
      * @return - The Favorite, if it exists, otherwise null
      * @throws ResourceNotFoundException - If there is no existing Favorite for the specified User and Monument, or
      *                                     there is no User for the specified userId
+     * @throws UnauthorizedException - If not logged in
      */
-    public Favorite getFavoriteByMonumentIdAndUserId(Integer monumentId, Integer userId) throws ResourceNotFoundException {
+    public Favorite getFavoriteByMonumentIdAndUserId(Integer monumentId, Integer userId)
+            throws ResourceNotFoundException, UnauthorizedException {
         User currentUser = this.userService.getCurrentUser();
 
         this.userService.requireUserExistsIfNotNull(userId);
@@ -58,8 +61,9 @@ public class FavoriteService {
      * @param userId - An optional override if not getting the favorites of the running user
      * @return - The Favorite, if it exists, otherwise null
      * @throws ResourceNotFoundException - If a userId is specified and no such User exists
+     * @throws UnauthorizedException - If not logged in
      */
-    public List<Favorite> getUserFavorites(Integer userId) throws ResourceNotFoundException {
+    public List<Favorite> getUserFavorites(Integer userId) throws ResourceNotFoundException, UnauthorizedException {
         User currentUser = this.userService.getCurrentUser();
 
         this.userService.requireUserExistsIfNotNull(userId);
@@ -76,7 +80,7 @@ public class FavoriteService {
     /**
      * @see FavoriteService#getUserFavorites(Integer)
      */
-    public List<Favorite> getUserFavorites() throws ResourceNotFoundException {
+    public List<Favorite> getUserFavorites() throws ResourceNotFoundException, UnauthorizedException {
         return this.getUserFavorites(null);
     }
 
@@ -86,8 +90,9 @@ public class FavoriteService {
      * @param monumentId - The Id of the Monument to favorite
      * @param userId - An optional override if not favoriting for the running user
      * @return - The created Favorite
+     * @throws UnauthorizedException - If not logged in
      */
-    public Favorite createFavorite(Integer monumentId, Integer userId) {
+    public Favorite createFavorite(Integer monumentId, Integer userId) throws UnauthorizedException {
         User currentUser = this.userService.getCurrentUser();
 
         Favorite favorite = new Favorite(
@@ -108,9 +113,10 @@ public class FavoriteService {
      * @param userId - An optional override if not deleting a favorite for the running user
      * @throws ResourceNotFoundException - If there is no existing Favorite for the specified User and Monument, or
      *                                     there is no User for the specified userId
+     * @throws UnauthorizedException - If not logged in
      */
     public void deleteFavorite(Integer monumentId, Integer userId)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, UnauthorizedException {
         Favorite favorite = getFavoriteByMonumentIdAndUserId(monumentId, userId);
         this.favoriteRepository.delete(favorite);
     }

--- a/src/main/java/com/monumental/services/UserService.java
+++ b/src/main/java/com/monumental/services/UserService.java
@@ -70,33 +70,9 @@ public class UserService extends ModelService<User> {
      * @throws UnauthorizedException - If the current user is not logged in
      */
     public UserAwareUserDetails getSession() throws UnauthorizedException {
-        return this.getSession(false);
-    }
-
-    /**
-     * Modified version of getSession that returns null instead of throwing an exception
-     * This is because throwing an exception will rollback the spring transaction automatically which is
-     * not always desirable
-     * @return UserAwareUserDetails if the user is logged in, or null if they are not
-     */
-    public UserAwareUserDetails getSessionSafely() {
-        return this.getSession(true);
-    }
-
-    /**
-     * Gets our custom Spring Security session object (UserAwareUserDetails) which includes our User.
-     * @param safely - If true, null will be returned if not logged in. If false, UnauthorizedException will be thrown
-     * @return UserAwareUserDetails - Custom Spring Security session object
-     * @throws UnauthorizedException - If the current user is not logged in and safely is false
-     */
-    private UserAwareUserDetails getSession(boolean safely) throws UnauthorizedException {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (!(principal instanceof UserAwareUserDetails)) {
-            if (safely) {
-                return null;
-            } else {
-                throw new UnauthorizedException(principal.getClass().getName());
-            }
+            throw new UnauthorizedException(principal.getClass().getName());
         }
         return (UserAwareUserDetails) principal;
     }
@@ -107,33 +83,8 @@ public class UserService extends ModelService<User> {
      * @throws UnauthorizedException - If the current user is not logged in
      */
     public User getCurrentUser() throws UnauthorizedException {
-        return this.getCurrentUser(false);
-    }
-
-    /**
-     * Modified version of getCurrentUser that returns null instead of throwing an exception
-     * This is because throwing an exception will rollback the spring transaction automatically which is
-     * not always desirable
-     * @return User - The logged in User if logged in, or null if not
-     */
-    public User getCurrentUserSafely() {
-        return this.getCurrentUser(true);
-    }
-
-    /**
-     * Gets our User object for the currently logged in user
-     * @param safely - if true null will be returned if not logged in, otherwise UnauthorizedException will be thrown
-     * @return User - The logged in User
-     * @throws UnauthorizedException - If the current user is not logged in and safely is false
-     */
-    private User getCurrentUser(boolean safely) throws UnauthorizedException {
-        UserAwareUserDetails session = this.getSession(safely);
-        if (session == null) {
-            if (safely) return null;
-            else throw new UnauthorizedException();
-        }
-        User user = session.getUser();
-        if (user == null && !safely) throw new UnauthorizedException();
+        User user = this.getSession().getUser();
+        if (user == null) throw new UnauthorizedException();
         return user;
     }
 

--- a/src/main/java/com/monumental/services/UserService.java
+++ b/src/main/java/com/monumental/services/UserService.java
@@ -128,12 +128,16 @@ public class UserService extends ModelService<User> {
      */
     @Transactional
     public void resetPassword(String email) {
-        User user = this.userRepository.getByEmail(email);
-        // Note: This is a security feature. We don't want the password reset form to tell everyone what email addresses are registered
-        if (user == null) {
-            return;
+        try {
+            User user = this.userRepository.getByEmail(email);
+            // Note: This is a security feature. We don't want the password reset form to tell everyone what email addresses are registered
+            if (user == null) {
+                return;
+            }
+            this.sendPasswordResetEmail(user, this.generateVerificationToken(user, VerificationToken.Type.PASSWORD_RESET));
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        this.sendPasswordResetEmail(user, this.generateVerificationToken(user, VerificationToken.Type.PASSWORD_RESET));
     }
 
     /**
@@ -304,7 +308,7 @@ public class UserService extends ModelService<User> {
         if (this.springMailUsername == null || this.springMailUsername.equals("")) {
             System.out.println("WARNING: You have not provided mail credentials, so the following email will NOT be sent: " + email);
         } else {
-            System.out.println("Sent email " + templateName + " to " + outboundEmailAddress);
+            System.out.println("Sent email " + templateName + " to " + recipientAddress);
             mailSender.send(email);
         }
     }

--- a/src/main/java/com/monumental/services/UserService.java
+++ b/src/main/java/com/monumental/services/UserService.java
@@ -70,9 +70,33 @@ public class UserService extends ModelService<User> {
      * @throws UnauthorizedException - If the current user is not logged in
      */
     public UserAwareUserDetails getSession() throws UnauthorizedException {
+        return this.getSession(false);
+    }
+
+    /**
+     * Modified version of getSession that returns null instead of throwing an exception
+     * This is because throwing an exception will rollback the spring transaction automatically which is
+     * not always desirable
+     * @return UserAwareUserDetails if the user is logged in, or null if they are not
+     */
+    public UserAwareUserDetails getSessionSafely() {
+        return this.getSession(true);
+    }
+
+    /**
+     * Gets our custom Spring Security session object (UserAwareUserDetails) which includes our User.
+     * @param safely - If true, null will be returned if not logged in. If false, UnauthorizedException will be thrown
+     * @return UserAwareUserDetails - Custom Spring Security session object
+     * @throws UnauthorizedException - If the current user is not logged in and safely is false
+     */
+    private UserAwareUserDetails getSession(boolean safely) throws UnauthorizedException {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (!(principal instanceof UserAwareUserDetails)) {
-            throw new UnauthorizedException(principal.getClass().getName());
+            if (safely) {
+                return null;
+            } else {
+                throw new UnauthorizedException(principal.getClass().getName());
+            }
         }
         return (UserAwareUserDetails) principal;
     }
@@ -83,8 +107,33 @@ public class UserService extends ModelService<User> {
      * @throws UnauthorizedException - If the current user is not logged in
      */
     public User getCurrentUser() throws UnauthorizedException {
-        User user = this.getSession().getUser();
-        if (user == null) throw new UnauthorizedException();
+        return this.getCurrentUser(false);
+    }
+
+    /**
+     * Modified version of getCurrentUser that returns null instead of throwing an exception
+     * This is because throwing an exception will rollback the spring transaction automatically which is
+     * not always desirable
+     * @return User - The logged in User if logged in, or null if not
+     */
+    public User getCurrentUserSafely() {
+        return this.getCurrentUser(true);
+    }
+
+    /**
+     * Gets our User object for the currently logged in user
+     * @param safely - if true null will be returned if not logged in, otherwise UnauthorizedException will be thrown
+     * @return User - The logged in User
+     * @throws UnauthorizedException - If the current user is not logged in and safely is false
+     */
+    private User getCurrentUser(boolean safely) throws UnauthorizedException {
+        UserAwareUserDetails session = this.getSession(safely);
+        if (session == null) {
+            if (safely) return null;
+            else throw new UnauthorizedException();
+        }
+        User user = session.getUser();
+        if (user == null && !safely) throw new UnauthorizedException();
         return user;
     }
 
@@ -134,7 +183,8 @@ public class UserService extends ModelService<User> {
             if (user == null) {
                 return;
             }
-            this.sendPasswordResetEmail(user, this.generateVerificationToken(user, VerificationToken.Type.PASSWORD_RESET));
+            VerificationToken token = this.generateVerificationToken(user, VerificationToken.Type.PASSWORD_RESET);
+            this.sendPasswordResetEmail(user, token);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/test/java/com/monumental/services/integrationtest/UserServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/UserServiceIntegrationTests.java
@@ -1,5 +1,6 @@
 package com.monumental.services.integrationtest;
 
+import com.monumental.exceptions.UnauthorizedException;
 import com.monumental.models.User;
 import com.monumental.repositories.UserRepository;
 import com.monumental.security.Role;
@@ -75,24 +76,36 @@ public class UserServiceIntegrationTests {
     @Test
     @WithUserDetails(RESEARCHER)
     public void getCurrentUser_researcher() {
-        User user = this.userService.getCurrentUser();
-        assertEquals(RESEARCHER, user.getEmail());
-        assertEquals(Role.RESEARCHER, user.getRole());
+        try {
+            User user = this.userService.getCurrentUser();
+            assertEquals(RESEARCHER, user.getEmail());
+            assertEquals(Role.RESEARCHER, user.getRole());
+        } catch (UnauthorizedException e) {
+            fail("User should be logged in.");
+        }
     }
 
     @Test
     @WithUserDetails(PARTNER)
     public void getCurrentUser_partner() {
-        User user = this.userService.getCurrentUser();
-        assertEquals(PARTNER, user.getEmail());
-        assertEquals(Role.PARTNER, user.getRole());
+        try {
+            User user = this.userService.getCurrentUser();
+            assertEquals(PARTNER, user.getEmail());
+            assertEquals(Role.PARTNER, user.getRole());
+        } catch (UnauthorizedException e) {
+            fail("User should be logged in.");
+        }
     }
 
     @Test
     @WithUserDetails(COLLABORATOR)
     public void getCurrentUser_collaborator() {
-        User user = this.userService.getCurrentUser();
-        assertEquals(COLLABORATOR, user.getEmail());
-        assertEquals(Role.COLLABORATOR, user.getRole());
+        try {
+            User user = this.userService.getCurrentUser();
+            assertEquals(COLLABORATOR, user.getEmail());
+            assertEquals(Role.COLLABORATOR, user.getRole());
+        } catch (UnauthorizedException e) {
+            fail("User should be logged in.");
+        }
     }
 }


### PR DESCRIPTION
There was a bug with JPA Auditing `UserService.getCurrentUser()` would throw `UnauthorizedException` if not logged in, which `JpaAuditConfiguration.getCurrentAuditor` would catch and return `null`.

Since `UnauthorizedException` extended `RuntimeException`, Spring would automatically rollback the database transaction. The end result is that any endpoint that did not require authentication was unable to use `@Transactional`

The fix was simply to make `UnauthorizedException` extend `Exception` instead of `RuntimeException`.