### PR TITLE
Replace org.opengeo:geodb with org.orbisgis:h2gis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,6 @@ sourceCompatibility = '10'
 
 repositories {
     mavenCentral()
-    maven {
-        url 'http://repo.boundlessgeo.com/main/'
-    }
 }
 
 springBoot {
@@ -48,19 +45,18 @@ dependencies {
     implementation('com.sun.xml.bind:jaxb-core:2.3.0')
     implementation('com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.10.0')
     implementation group: 'org.hibernate', name: 'hibernate-search-orm', version: '5.11.3.Final'
-    implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.1.0.Final'
+    implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.4.14.Final'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     implementation('com.google.maps:google-maps-services:0.10.1')
-    implementation('com.bedatadriven:jackson-datatype-jts:2.4')
+    implementation('com.graphhopper.external:jackson-datatype-jts:0.10-2.5-1')
     implementation('com.amazonaws:aws-java-sdk-s3:1.11.665')
     implementation('com.opencsv:opencsv:3.7')
     implementation('io.jsonwebtoken:jjwt:0.9.1')
-    // Geodb includes H2 as a dependency, so no need to import it separately
-    implementation group: 'org.opengeo', name: 'geodb', version: '0.8'
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('junit:junit:4.12')
     testImplementation('org.mockito:mockito-core:2.13.0')
     testImplementation('org.springframework.security:spring-security-test')
+    testImplementation('org.orbisgis:h2gis:1.5.0')
 }
 
 node {

--- a/src/main/java/com/monumental/models/Monument.java
+++ b/src/main/java/com/monumental/models/Monument.java
@@ -1,9 +1,13 @@
 package com.monumental.models;
 
+import com.bedatadriven.jackson.datatype.jts.serialization.GeometryDeserializer;
+import com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.monumental.util.string.StringHelper;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import org.hibernate.LazyInitializationException;
 
 import javax.persistence.*;
@@ -32,6 +36,8 @@ public class Monument extends Model implements Serializable {
     @Column(name = "date")
     private Date date;
 
+    @JsonSerialize(using = GeometrySerializer.class)
+    @JsonDeserialize(using = GeometryDeserializer.class)
     @Column(name = "coordinates", columnDefinition = "geometry")
     private Point coordinates;
 

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -14,10 +14,10 @@ import com.monumental.util.async.AsyncJob;
 import com.monumental.util.csvparsing.*;
 import com.monumental.util.string.StringHelper;
 import com.opencsv.CSVReader;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
@@ -390,7 +390,7 @@ public class MonumentService extends ModelService<Monument> {
 
         GeometryFactory geometryFactory = new GeometryFactory();
 
-        Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+        Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude, 0));
         point.setSRID(coordinateSrid);
 
         return point;

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
@@ -15,7 +15,7 @@ import com.monumental.repositories.TagRepository;
 import com.monumental.services.GoogleMapsService;
 import com.monumental.services.MonumentService;
 import com.monumental.services.TagService;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/monumental/services/unittest/MonumentServiceUnitTests.java
+++ b/src/test/java/com/monumental/services/unittest/MonumentServiceUnitTests.java
@@ -2,7 +2,7 @@ package com.monumental.services.unittest;
 
 import com.monumental.models.Monument;
 import com.monumental.services.MonumentService;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterResultUnitTests.java
+++ b/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterResultUnitTests.java
@@ -4,7 +4,7 @@ import com.monumental.models.Monument;
 import com.monumental.models.Reference;
 import com.monumental.services.MonumentService;
 import com.monumental.util.csvparsing.CsvMonumentConverterResult;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,7 +10,7 @@ logging.level.org.springframework.web=ERROR
 logging.level.org.hibernate.engine.jdbc.internal.LobCreatorBuilder=NONE
 
 # Data configurations
-spring.datasource.platform=geodb
+spring.datasource.platform=h2
 spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.show-sql = true


### PR DESCRIPTION
It looks like `org.opengeo:geodb` is dead, or more specifically the repo it's hosted at (repo.boundlessgeo.com). After much pain I found `org.orbisgis:h2gis` as a replacement for this (it's a little newer and still active)

Some very helpful threads in this process:
* https://stackoverflow.com/a/53138322/10044594
* The hint to switch from `com.vividsolutions` to `org.locationtech` [here](http://www.h2gis.org/news/2019/03/18/h2gis-1.5.0-released/)
* https://stackoverflow.com/a/59348806/10044594