### PR TITLE
Basic SEO Sitemap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation('com.amazonaws:aws-java-sdk-s3:1.11.665')
     implementation('com.opencsv:opencsv:3.7')
     implementation('io.jsonwebtoken:jjwt:0.9.1')
+    implementation('com.github.dfabulich:sitemapgen4j:1.1.2')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('junit:junit:4.12')
     testImplementation('org.mockito:mockito-core:2.13.0')

--- a/src/main/java/com/monumental/controllers/SitemapController.java
+++ b/src/main/java/com/monumental/controllers/SitemapController.java
@@ -36,7 +36,6 @@ public class SitemapController {
             this.publicUrl + "/",
             this.publicUrl + "/about",
             this.publicUrl + "/map",
-            this.publicUrl + "/create",
             this.publicUrl + "/search"
         );
 

--- a/src/main/java/com/monumental/controllers/SitemapController.java
+++ b/src/main/java/com/monumental/controllers/SitemapController.java
@@ -1,0 +1,51 @@
+package com.monumental.controllers;
+
+import com.monumental.models.Monument;
+import com.monumental.repositories.MonumentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.redfin.sitemapgenerator.WebSitemapGenerator;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
+@RestController
+public class SitemapController {
+
+    @Value("${PUBLIC_URL:http://localhost:3000}")
+    private String publicUrl;
+
+    @Autowired
+    private MonumentRepository monumentRepository;
+
+    /**
+     * Generates an XML Sitemap for Google to index the site
+     */
+    @RequestMapping(path = "/sitemap.xml", produces = APPLICATION_XML_VALUE)
+    public void getSitemap(HttpServletResponse response) throws IOException {
+        response.setContentType(APPLICATION_XML_VALUE);
+
+        WebSitemapGenerator sitemap = new WebSitemapGenerator(this.publicUrl);
+
+        sitemap.addUrls(
+            this.publicUrl + "/",
+            this.publicUrl + "/about",
+            this.publicUrl + "/map",
+            this.publicUrl + "/create",
+            this.publicUrl + "/search"
+        );
+
+        for (Monument monument : this.monumentRepository.findAllByIsActive(true)) {
+            sitemap.addUrl(this.publicUrl + "/monuments/" + monument.getId());
+        }
+
+        try (Writer writer = response.getWriter()) {
+            writer.append(String.join("", sitemap.writeAsStrings()));
+        }
+    }
+}


### PR DESCRIPTION
I am trying to wade into the world of SEO slightly to make sure the site is at least indexed by Google, one of the steps in that process is creating an XML sitemap which describes the pages on your site. I created a really simple one with our main static URLs and then a dynamic list of all the monument pages. This is a little iffy because it uses the url format `https://monuments.us.org/monuments/{id}` instead of the full `https://monuments.us.org/monuments/{id}/{slug}` but I think it will still work correctly.

The sitemap looks like this (with a bunch more monuments below). In production the URLs will be `https://monuments.us.org/` not `http://localhost:3000/`
![](https://i.imgur.com/oZ5uLSM.png)