### PR TITLE
Bug Fixes

### DIFF
--- a/client/src/components/About/AboutInformation/AboutInformation.js
+++ b/client/src/components/About/AboutInformation/AboutInformation.js
@@ -191,6 +191,12 @@ export default class AboutInformation extends React.Component {
                             description={'Number of Monuments tagged with: ' + monumentStatistics.randomTagName}
                         />
                     </div>
+                    <div className="statistics-row last">
+                        <StatisticCard statistic={monumentStatistics.mostPopularTagName}
+                                       description={`Most Popular Tag (used ${monumentStatistics.mostPopularTagUses} times)`}/>
+                        <StatisticCard statistic={monumentStatistics.mostPopularMaterialName}
+                                       description={`Most Popular Material (used ${monumentStatistics.mostPopularMaterialUses} times)`}/>
+                    </div>
                 </div>
                 <div className="charts-container">
                     <NumberOfMonumentsByStateBarChart

--- a/client/src/components/About/AboutInformation/AboutInformation.js
+++ b/client/src/components/About/AboutInformation/AboutInformation.js
@@ -193,9 +193,11 @@ export default class AboutInformation extends React.Component {
                     </div>
                     <div className="statistics-row last">
                         <StatisticCard statistic={monumentStatistics.mostPopularTagName}
-                                       description={`Most Popular Tag (used ${monumentStatistics.mostPopularTagUses} times)`}/>
+                                       description={`Most Popular Tag (used ${monumentStatistics.mostPopularTagUses} times)`}
+                                       link={`/search/?tags=${monumentStatistics.mostPopularTagName}`}/>
                         <StatisticCard statistic={monumentStatistics.mostPopularMaterialName}
-                                       description={`Most Popular Material (used ${monumentStatistics.mostPopularMaterialUses} times)`}/>
+                                       description={`Most Popular Material (used ${monumentStatistics.mostPopularMaterialUses} times)`}
+                                       link={`/search/?materials=${monumentStatistics.mostPopularMaterialName}`}/>
                     </div>
                 </div>
                 <div className="charts-container">

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -326,6 +326,11 @@ export default class CreateOrUpdateForm extends React.Component {
                 latitude.isValid = false;
                 latitude.message = 'Latitude must not be blank';
                 formIsValid = false;
+            } else if (latitude.value.includes('°')) {
+                latitude.isValid = false;
+                latitude.message = 'Please use decimal coordinates, not degrees. ' +
+                    'To convert, input your degrees into Google Maps and copy the new numbers here.';
+                formIsValid = false;
             } else if (!validator.matches(latitude.value, latitudeRegex)) {
                 latitude.isValid = false;
                 latitude.message = 'Latitude must be valid';
@@ -335,7 +340,13 @@ export default class CreateOrUpdateForm extends React.Component {
                 longitude.isValid = false;
                 longitude.message = 'Longitude must not be blank';
                 formIsValid = false;
-            } else if (!validator.matches(longitude.value, longitudeRegex)) {
+            } else if (longitude.value.includes('°')) {
+                longitude.isValid = false;
+                longitude.message = 'Please use decimal coordinates, not degrees. ' +
+                    'To convert, input your degrees into Google Maps and copy the new numbers here.';
+                formIsValid = false;
+            }
+            else if (!validator.matches(longitude.value, longitudeRegex)) {
                 longitude.isValid = false;
                 longitude.message = 'Longitude must be valid';
                 formIsValid = false;
@@ -1107,8 +1118,9 @@ export default class CreateOrUpdateForm extends React.Component {
                         <ImageUploader
                             withIcon={false}
                             imgExtension={['.jpg', '.png']}
+                            maxFileSize={5000000}
                             label=""
-                            fileSizeError="File size is too large"
+                            fileSizeError="File size is too large. Maximum file size is 5MB"
                             fileTypeError="File type is not supported"
                             withPreview={true}
                             onChange={(files) => this.handleImageUploaderChange(files)}

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -988,8 +988,8 @@ export default class CreateOrUpdateForm extends React.Component {
         return (
             <div className="create-form-container">
                 {monument
-                    ? <div className="h5 update">{action} an existing Monument or Memorial</div>
-                    : <div className="h5 create">{action} a new Monument or Memorial</div>}
+                    ? <div className="h4 update">{action} an existing Monument or Memorial</div>
+                    : <div className="h4 create">{action} a new Monument or Memorial</div>}
 
                 <Form onSubmit={(event) => this.handleSubmit(event)}>
                     {/* Title */}

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -1120,7 +1120,7 @@ export default class CreateOrUpdateForm extends React.Component {
                             imgExtension={['.jpg', '.png']}
                             maxFileSize={5000000}
                             label=""
-                            fileSizeError="File size is too large. Maximum file size is 5MB"
+                            fileSizeError="- File is too large. The maximum file size is 5MB"
                             fileTypeError="File type is not supported"
                             withPreview={true}
                             onChange={(files) => this.handleImageUploaderChange(files)}

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -335,7 +335,17 @@ export default class CreateOrUpdateForm extends React.Component {
                 latitude.isValid = false;
                 latitude.message = 'Latitude must be valid';
                 formIsValid = false;
+            } else {
+                const latAsDouble = parseFloat(latitude.value);
+                // Alaska is the furthest north location and its latitude is approximately 71
+                // The American Samoa is the furthest south location and its latitude is approximately -14
+                if (latAsDouble > 72 || latAsDouble < -15) {
+                    latitude.isValid = false;
+                    latitude.message = 'Latitude is not near the United States';
+                    formIsValid = false;
+                }
             }
+
             if (validator.isEmpty(longitude.value)) {
                 longitude.isValid = false;
                 longitude.message = 'Longitude must not be blank';
@@ -350,6 +360,15 @@ export default class CreateOrUpdateForm extends React.Component {
                 longitude.isValid = false;
                 longitude.message = 'Longitude must be valid';
                 formIsValid = false;
+            } else {
+                const lonAsDouble = parseFloat(longitude.value);
+                // Guam is the furthest west location and its longitude is approximately 144
+                // Puerto Rico is the furthest east location and its longitude is approximately -65
+                if (lonAsDouble > -64 && !(lonAsDouble < 180 && lonAsDouble > 143)) {
+                    longitude.isValid = false;
+                    longitude.message = 'Longitude is not near the United States';
+                    formIsValid = false;
+                }
             }
         } else {
             locationType.isValid = false;

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
@@ -1,10 +1,9 @@
 @import "../../theme";
 
 .create-form-container {
-    padding-left: 22rem;
-
-    .h5 {
+    .h4 {
         padding-bottom: 1rem;
+        text-align: center;
     }
 
     .form-label {
@@ -75,7 +74,7 @@
         border-style: solid;
         border-color: lightgray;
         border-width: thin;
-        padding: 1.5rem;
+        padding: 1.0rem 1.5rem 1.5rem 1.5rem;
         width: 30rem;
         margin-bottom: 1rem;
 

--- a/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
+++ b/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
@@ -12,6 +12,8 @@ export default class DuplicateMonuments extends React.Component {
     render() {
         const { duplicates, onCancel, onConfirm, showing } = this.props;
 
+        console.log(duplicates);
+
         return (
             <Modal show={showing} onHide={onCancel}>
                 <Modal.Header className="duplicate-monuments">
@@ -33,11 +35,7 @@ export default class DuplicateMonuments extends React.Component {
                         can continue with your suggestion.
                     </p>
                     <div className="duplicates-container">
-                        <SearchResults
-                            monuments={duplicates}
-                            limit={25}
-                            page={1}
-                        />
+                        <SearchResults monuments={duplicates} limit={25} page={1} monumentUri={'/monuments'}/>
                     </div>
                 </Modal.Body>
                 <Modal.Footer className="duplicate-monuments">

--- a/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
+++ b/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
@@ -12,8 +12,6 @@ export default class DuplicateMonuments extends React.Component {
     render() {
         const { duplicates, onCancel, onConfirm, showing } = this.props;
 
-        console.log(duplicates);
-
         return (
             <Modal show={showing} onHide={onCancel}>
                 <Modal.Header className="duplicate-monuments">

--- a/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
+++ b/client/src/components/Monument/DuplicateMonuments/DuplicateMonuments.js
@@ -33,7 +33,7 @@ export default class DuplicateMonuments extends React.Component {
                         can continue with your suggestion.
                     </p>
                     <div className="duplicates-container">
-                        <SearchResults monuments={duplicates} limit={25} page={1} monumentUri={'/monuments'}/>
+                        <SearchResults monuments={duplicates} limit={25} page={1}/>
                     </div>
                 </Modal.Body>
                 <Modal.Footer className="duplicate-monuments">

--- a/client/src/components/Search/SearchResult/SearchResult.js
+++ b/client/src/components/Search/SearchResult/SearchResult.js
@@ -12,7 +12,7 @@ import Thumbnail from '../../Monument/Images/Thumbnails/Thumbnail/Thumbnail';
 export default class SearchResult extends React.Component {
 
     render() {
-        const { monument, index, includeIndexInTitle, hideImages, searchUri, monumentUri } = this.props;
+        const { monument, index, includeIndexInTitle, hideImages, searchUri, monumentUri='/monuments' } = this.props;
         const image = monument && monument.images ? monument.images.find(monument => monument.isPrimary) : null;
         const title = includeIndexInTitle ?  (index + 1) + ". " + monument.title : monument.title;
 

--- a/client/src/components/Search/SearchResults/SearchResults.js
+++ b/client/src/components/Search/SearchResults/SearchResults.js
@@ -4,7 +4,7 @@ import SearchResult from '../SearchResult/SearchResult';
 export default class SearchResults extends React.Component {
 
     render() {
-        const { monuments, limit, page, hideImages, monumentUri, searchUri } = this.props;
+        const { monuments, limit, page, hideImages, monumentUri='/monuments', searchUri } = this.props;
         if (monuments && monuments.length) {
             return (
                 <div>{

--- a/client/src/components/Search/TagsSearch/TagsSearch.js
+++ b/client/src/components/Search/TagsSearch/TagsSearch.js
@@ -61,9 +61,10 @@ class TagsSearch extends React.Component {
           <div/>
         );
 
-        if (allowTagCreation && searchQuery !== '' && !selectedTags.find(tag => tag.name === searchQuery)
-            && !createdTags.find(tag => tag.name === searchQuery))
-        {
+        if (allowTagCreation && searchQuery !== ''
+            && !selectedTags.find(tag => tag.name.toLowerCase() === searchQuery.toLowerCase())
+            && !createdTags.find(tag => tag.name.toLowerCase() === searchQuery.toLowerCase())
+            && !visibleSearchResults.find(tag => tag.name.toLowerCase() === searchQuery.toLowerCase())) {
             const tag = {
                 id: createdTagsKey,
                 name: searchQuery,

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
@@ -192,6 +192,7 @@ class CreateMonumentPage extends React.Component {
                         action={action}
                     />
                 </div>
+                <div className="column"/>
 
                 {this.renderDuplicateMonuments()}
                 {this.renderNoImageModal()}

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.scss
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.scss
@@ -10,7 +10,6 @@
   height: 100%;
 
   .column {
-    flex: 1 1 100%;
     padding: 1rem 0;
   }
 
@@ -18,16 +17,17 @@
     flex-direction: row;
 
     .column {
-      flex-basis: 35%;
-      padding: 0 1rem;
+      flex: 1 1 0px;
+    }
 
-      &.left {
-        flex-basis: 20%;
-      }
+    .form-column {
+      display: flex;
+      justify-content: center;
+    }
 
-      &.form-column {
-        flex-basis: 80%;
-      }
+    .thank-you-column .card {
+        max-width: fit-content;
+        margin-left: 1rem;
     }
   }
 }

--- a/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
+++ b/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.js
@@ -169,6 +169,7 @@ class UpdateMonumentPage extends React.Component {
                         action={action}
                     />
                 </div>
+                <div className="column"/>
 
                 {this.renderNoImageModal()}
                 {this.renderReviewModal()}

--- a/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.scss
+++ b/client/src/pages/UpdateMonumentPage/UpdateMonumentPage.scss
@@ -10,7 +10,6 @@
   height: 100%;
 
   .column {
-    flex: 1 1 100%;
     padding: 1rem 0;
   }
 
@@ -18,16 +17,17 @@
     flex-direction: row;
 
     .column {
-      flex-basis: 35%;
-      padding: 0 1rem;
+      flex: 1 1 0px;
+    }
 
-      &.left {
-        flex-basis: 20%;
-      }
+    .form-column {
+      display: flex;
+      justify-content: center;
+    }
 
-      &.form-column {
-        flex-basis: 80%;
-      }
+    .thank-you-column .card {
+      max-width: fit-content;
+      margin-left: 1rem;
     }
   }
 }

--- a/src/main/java/com/monumental/controllers/helpers/MonumentAboutPageStatistics.java
+++ b/src/main/java/com/monumental/controllers/helpers/MonumentAboutPageStatistics.java
@@ -29,6 +29,14 @@ public class MonumentAboutPageStatistics {
 
     private Integer vietnamVeteransMemorialId;
 
+    private String mostPopularTagName;
+
+    private int mostPopularTagUses;
+
+    private String mostPopularMaterialName;
+
+    private int mostPopularMaterialUses;
+
     public int getTotalNumberOfMonuments() {
         return this.totalNumberOfMonuments;
     }
@@ -107,5 +115,37 @@ public class MonumentAboutPageStatistics {
 
     public void setVietnamVeteransMemorialId(Integer vietnamVeteransMemorialId) {
         this.vietnamVeteransMemorialId = vietnamVeteransMemorialId;
+    }
+
+    public String getMostPopularTagName() {
+        return this.mostPopularTagName;
+    }
+
+    public void setMostPopularTagName(String mostPopularTagName) {
+        this.mostPopularTagName = mostPopularTagName;
+    }
+
+    public int getMostPopularTagUses() {
+        return this.mostPopularTagUses;
+    }
+
+    public void setMostPopularTagUses(int mostPopularTagUses) {
+        this.mostPopularTagUses = mostPopularTagUses;
+    }
+
+    public String getMostPopularMaterialName() {
+        return this.mostPopularMaterialName;
+    }
+
+    public void setMostPopularMaterialName(String mostPopularMaterialName) {
+        this.mostPopularMaterialName = mostPopularMaterialName;
+    }
+
+    public int getMostPopularMaterialUses() {
+        return this.mostPopularMaterialUses;
+    }
+
+    public void setMostPopularMaterialUses(int mostPopularMaterialUses) {
+        this.mostPopularMaterialUses = mostPopularMaterialUses;
     }
 }

--- a/src/main/java/com/monumental/repositories/TagRepository.java
+++ b/src/main/java/com/monumental/repositories/TagRepository.java
@@ -1,13 +1,11 @@
 package com.monumental.repositories;
 
 import com.monumental.models.Tag;
-import javassist.compiler.ast.Pair;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.Tuple;
 import javax.transaction.Transactional;
 import java.util.List;
 

--- a/src/main/java/com/monumental/repositories/TagRepository.java
+++ b/src/main/java/com/monumental/repositories/TagRepository.java
@@ -1,11 +1,13 @@
 package com.monumental.repositories;
 
 import com.monumental.models.Tag;
+import javassist.compiler.ast.Pair;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.Tuple;
 import javax.transaction.Transactional;
 import java.util.List;
 
@@ -38,4 +40,11 @@ public interface TagRepository extends JpaRepository<Tag, Integer> {
     List<Tag> getAllByName(String name);
 
     List<Tag> getAllByNameIn(List<String> names);
+
+    /**
+     * Get all Tags (including Materials) in descending order of most uses
+     * This returns a List<Object[]>, where Object[0] is the Tag and Object[1] is the count
+     */
+    @Query("select t, count(t.name) as tCount from Tag t join t.monumentTags mt on t.id = mt.tag.id group by t.id order by tCount desc")
+    List<Object[]> getAllOrderByMostUsedDesc();
 }

--- a/src/main/java/com/monumental/services/GoogleMapsService.java
+++ b/src/main/java/com/monumental/services/GoogleMapsService.java
@@ -25,7 +25,9 @@ public class GoogleMapsService {
                 System.out.println("[GOOGLE MAPS SERVICE]: Making reverse geocode request for lat/lon: (" + lat + ", " + lon + ")");
                 GeocodingResult[] results = GeocodingApi.reverseGeocode(context, new LatLng(lat, lon))
                         .await();
-                return results[0].formattedAddress;
+                if (results.length > 0) {
+                    return results[0].formattedAddress;
+                }
             }
         } catch (ApiException | InterruptedException | IOException e) {
             System.out.println("[GOOGLE MAPS SERVICE]: Error when attempting to make reverse geocode request for lat/lon: (" + lat + ", " + lon + ")");
@@ -50,7 +52,9 @@ public class GoogleMapsService {
                 System.out.println("[GOOGLE MAPS SERVICE]: Making geocode request for address: " + address);
                 GeocodingResult[] results = GeocodingApi.geocode(context, address)
                         .await();
-                return results[0].geometry;
+                if (results.length > 0) {
+                    return results[0].geometry;
+                }
             }
         } catch (ApiException | InterruptedException | IOException e) {
             System.out.println("[GOOGLE MAPS SERVICE]: Error when attempting to make geocode request for address: " + address);

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -83,6 +83,12 @@ public class CsvMonumentConverter {
                         else {
                             try {
                                 latitude = Double.parseDouble(value);
+
+                                // Alaska is the furthest north location and its latitude is approximately 71
+                                // The American Samoa is the furthest south location and its latitude is approximately -14
+                                if (latitude > 72 || latitude < -15) {
+                                    result.getErrors().add("Latitude is not near the United States");
+                                }
                             } catch (NumberFormatException e) {
                                 result.getWarnings().add("Latitude should be a valid number.");
                             } finally {
@@ -99,6 +105,12 @@ public class CsvMonumentConverter {
                         else {
                             try {
                                 longitude = Double.parseDouble(value);
+
+                                // Guam is the furthest west location and its longitude is approximately 144
+                                // Puerto Rico is the furthest east location and its longitude is approximately -65
+                                if (longitude > -64 && !(longitude < 180 && longitude > 143)) {
+                                    result.getErrors().add("Longitude is not near the United States");
+                                }
                             } catch (NumberFormatException e) {
                                 result.getWarnings().add("Longitude should be a valid number.");
                             } finally {

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -19,6 +19,9 @@ import java.util.zip.ZipFile;
  */
 public class CsvMonumentConverter {
 
+    private static final String coordinatesDMSFormatWarning = "Please use decimal coordinates, not degrees. To " +
+            "convert, input your degrees into Google Maps.";
+
     /**
      * Convert CSV rows into CsvMonumentConverterResults
      * @param csvRows - List of String Arrays of cells in a CSV
@@ -72,21 +75,35 @@ public class CsvMonumentConverter {
                         suggestion.setInscription(value);
                         break;
                     case "latitude":
-                        try {
-                            latitude = Double.parseDouble(value);
-                        } catch (NumberFormatException e) {
-                            result.getWarnings().add("Latitude should be a valid number.");
-                        } finally {
-                            suggestion.setLatitude(latitude);
+                        if (value.contains("°")) {
+                            if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
+                                result.getWarnings().add(coordinatesDMSFormatWarning);
+                            }
+                        }
+                        else {
+                            try {
+                                latitude = Double.parseDouble(value);
+                            } catch (NumberFormatException e) {
+                                result.getWarnings().add("Latitude should be a valid number.");
+                            } finally {
+                                suggestion.setLatitude(latitude);
+                            }
                         }
                         break;
                     case "longitude":
-                        try {
-                            longitude = Double.parseDouble(value);
-                        } catch (NumberFormatException e) {
-                            result.getWarnings().add("Longitude should be a valid number.");
-                        } finally {
-                            suggestion.setLongitude(longitude);
+                        if (value.contains("°")) {
+                            if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
+                                result.getWarnings().add(coordinatesDMSFormatWarning);
+                            }
+                        }
+                        else {
+                            try {
+                                longitude = Double.parseDouble(value);
+                            } catch (NumberFormatException e) {
+                                result.getWarnings().add("Longitude should be a valid number.");
+                            } finally {
+                                suggestion.setLongitude(longitude);
+                            }
                         }
                         break;
                     case "city":
@@ -210,6 +227,20 @@ public class CsvMonumentConverter {
             names.add(name);
         }
         return names;
+    }
+
+    /**
+     * Static method to add the beginning and ending quotes to a specified String
+     * Does nothing if there are already beginning and ending quotes
+     * @param string - the String to add the quotes to
+     * @return String - the updated String, with beginning and ending quotes
+     */
+    private static String addBeginningAndEndingQuotes(String string) {
+        if (string.startsWith("\"") && string.endsWith("\"")) {
+            return string;
+        }
+
+        return "\"" + string + "\"";
     }
 
     /**

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -145,7 +145,7 @@ public class CsvMonumentConverter {
                                         result.getWarnings().add("Image file is too large. Maximum file size is 5MB.");
                                     }
                                     else {
-                                        result.getImageFiles().add(ZipFileHelper.convertZipEntryToFile(zipFile, imageZipEntry));
+                                        result.getImageFiles().add(imageFile);
                                     }
                                 } catch (IOException e) {
                                     result.getErrors().add("Failed to read image file from .zip");
@@ -239,20 +239,6 @@ public class CsvMonumentConverter {
             names.add(name);
         }
         return names;
-    }
-
-    /**
-     * Static method to add the beginning and ending quotes to a specified String
-     * Does nothing if there are already beginning and ending quotes
-     * @param string - the String to add the quotes to
-     * @return String - the updated String, with beginning and ending quotes
-     */
-    private static String addBeginningAndEndingQuotes(String string) {
-        if (string.startsWith("\"") && string.endsWith("\"")) {
-            return string;
-        }
-
-        return "\"" + string + "\"";
     }
 
     /**

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -75,47 +75,45 @@ public class CsvMonumentConverter {
                         suggestion.setInscription(value);
                         break;
                     case "latitude":
-                        if (value.contains("°")) {
-                            if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
-                                result.getWarnings().add(coordinatesDMSFormatWarning);
-                            }
-                        }
-                        else {
-                            try {
-                                latitude = Double.parseDouble(value);
-
-                                // Alaska is the furthest north location and its latitude is approximately 71
-                                // The American Samoa is the furthest south location and its latitude is approximately -14
-                                if (latitude > 72 || latitude < -15) {
-                                    result.getErrors().add("Latitude is not near the United States");
+                        try {
+                            if (value.contains("°")) {
+                                if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
+                                    result.getWarnings().add(coordinatesDMSFormatWarning);
                                 }
-                            } catch (NumberFormatException e) {
-                                result.getWarnings().add("Latitude should be a valid number.");
-                            } finally {
-                                suggestion.setLatitude(latitude);
                             }
+
+                            latitude = Double.parseDouble(value);
+
+                            // Alaska is the furthest north location and its latitude is approximately 71
+                            // The American Samoa is the furthest south location and its latitude is approximately -14
+                            if (latitude > 72 || latitude < -15) {
+                                result.getErrors().add("Latitude is not near the United States");
+                            }
+                        } catch (NumberFormatException e) {
+                            result.getWarnings().add("Latitude should be a valid number.");
+                        } finally {
+                            suggestion.setLatitude(latitude);
                         }
                         break;
                     case "longitude":
-                        if (value.contains("°")) {
-                            if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
-                                result.getWarnings().add(coordinatesDMSFormatWarning);
-                            }
-                        }
-                        else {
-                            try {
-                                longitude = Double.parseDouble(value);
-
-                                // Guam is the furthest west location and its longitude is approximately 144
-                                // Puerto Rico is the furthest east location and its longitude is approximately -65
-                                if (longitude > -64 && !(longitude < 180 && longitude > 143)) {
-                                    result.getErrors().add("Longitude is not near the United States");
+                        try {
+                            if (value.contains("°")) {
+                                if (!result.getWarnings().contains(coordinatesDMSFormatWarning)) {
+                                    result.getWarnings().add(coordinatesDMSFormatWarning);
                                 }
-                            } catch (NumberFormatException e) {
-                                result.getWarnings().add("Longitude should be a valid number.");
-                            } finally {
-                                suggestion.setLongitude(longitude);
                             }
+
+                            longitude = Double.parseDouble(value);
+
+                            // Guam is the furthest west location and its longitude is approximately 144
+                            // Puerto Rico is the furthest east location and its longitude is approximately -65
+                            if (longitude > -64 && !(longitude < 180 && longitude > 143)) {
+                                result.getErrors().add("Longitude is not near the United States");
+                            }
+                        } catch (NumberFormatException e) {
+                            result.getWarnings().add("Longitude should be a valid number.");
+                        } finally {
+                            suggestion.setLongitude(longitude);
                         }
                         break;
                     case "city":

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.monumental.models.suggestions.CreateMonumentSuggestion;
 import com.monumental.services.MonumentService;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.format.DateTimeParseException;
 import java.util.*;
@@ -110,7 +111,13 @@ public class CsvMonumentConverter {
                                 result.getWarnings().add("Could not find image in .zip file. File may be missing or named incorrectly.");
                             } else {
                                 try {
-                                    result.getImageFiles().add(ZipFileHelper.convertZipEntryToFile(zipFile, imageZipEntry));
+                                    File imageFile = ZipFileHelper.convertZipEntryToFile(zipFile, imageZipEntry);
+                                    if (imageFile.length() > 5000000) {
+                                        result.getWarnings().add("Image file is too large. Maximum file size is 5MB.");
+                                    }
+                                    else {
+                                        result.getImageFiles().add(ZipFileHelper.convertZipEntryToFile(zipFile, imageZipEntry));
+                                    }
                                 } catch (IOException e) {
                                     result.getErrors().add("Failed to read image file from .zip");
                                 }

--- a/src/test/java/com/monumental/repositories/integrationtest/TagRepositoryIntegrationTests.java
+++ b/src/test/java/com/monumental/repositories/integrationtest/TagRepositoryIntegrationTests.java
@@ -181,4 +181,86 @@ public class TagRepositoryIntegrationTests {
         assertEquals(3, this.tagRepository.getAllByMonumentIdAndIsMaterial(monument.getId(), false).size());
         assertEquals(3, this.tagRepository.getAllByMonumentIdAndIsMaterial(monument.getId(), true).size());
     }
+
+    /** getAllOrderByMostUsedDesc Tests **/
+
+    @Test
+    public void testTagRepository_getAllOrderByMostUsedDesc_NoTags() {
+        List<Object[]> result = this.tagRepository.getAllOrderByMostUsedDesc();
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testTagRepository_getAllOrderByMostUsedDesc_OneTag_NoUses() {
+        this.tagService.createTag("Tag", new ArrayList<>(), false);
+
+        List<Object[]> result = this.tagRepository.getAllOrderByMostUsedDesc();
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testTagRepository_getAllOrderByMostUsedDesc_OneTag_OneUse() {
+        Monument monument = new Monument();
+        monument = this.monumentRepository.save(monument);
+
+        ArrayList<Monument> monuments = new ArrayList<>();
+        monuments.add(monument);
+
+        this.tagService.createTag("Tag", monuments, false);
+
+        List<Object[]> result = this.tagRepository.getAllOrderByMostUsedDesc();
+        assertEquals(1, result.size());
+
+        Tag tagResult = (Tag) result.get(0)[0];
+        assertEquals("Tag", tagResult.getName());
+
+        long countResult = (long) result.get(0)[1];
+        assertEquals(1, countResult);
+    }
+
+    @Test
+    public void testTagRepository_getAllOrderByMostUsedDesc_MultipleTags_CorrectOrdering() {
+        Monument monument1 = new Monument();
+        monument1 = this.monumentRepository.save(monument1);
+
+        Monument monument2 = new Monument();
+        monument2 = this.monumentRepository.save(monument2);
+
+        Monument monument3 = new Monument();
+        monument3 = this.monumentRepository.save(monument3);
+
+        ArrayList<Monument> tag1Monuments = new ArrayList<>();
+        tag1Monuments.add(monument1);
+        tag1Monuments.add(monument2);
+        tag1Monuments.add(monument3);
+
+        ArrayList<Monument> tag2Monuments = new ArrayList<>();
+        tag2Monuments.add(monument1);
+        tag2Monuments.add(monument2);
+
+        ArrayList<Monument> tag3Monuments = new ArrayList<>();
+        tag3Monuments.add(monument1);
+
+        this.tagService.createTag("Tag 1", tag1Monuments, false);
+        this.tagService.createTag("Tag 2", tag2Monuments, false);
+        this.tagService.createTag("Tag 3", tag3Monuments, false);
+
+        List<Object[]> result = this.tagRepository.getAllOrderByMostUsedDesc();
+        assertEquals(3, result.size());
+
+        Tag firstTagResult = (Tag) result.get(0)[0];
+        assertEquals("Tag 1", firstTagResult.getName());
+        long firstCountResult = (long) result.get(0)[1];
+        assertEquals(3, firstCountResult);
+
+        Tag secondTagResult = (Tag) result.get(1)[0];
+        assertEquals("Tag 2", secondTagResult.getName());
+        long secondCountResult = (long) result.get(1)[1];
+        assertEquals(2, secondCountResult);
+
+        Tag thirdTagResult = (Tag) result.get(2)[0];
+        assertEquals("Tag 3", thirdTagResult.getName());
+        long thirdCountResult = (long) result.get(2)[1];
+        assertEquals(1, thirdCountResult);
+    }
 }

--- a/src/test/java/com/monumental/services/integrationtest/AuditingIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/AuditingIntegrationTests.java
@@ -100,7 +100,6 @@ public class AuditingIntegrationTests {
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
                 new UserAwareUserDetails(partner), password
         ));
-        List<User> users = this.userRepository.findAll();
         monument = updateMonument(monument);
         assertNotNull(monument.getLastModifiedDate());
         assertTrue(monument.getLastModifiedDate().getTime() > monument.getCreatedDate().getTime());

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
@@ -450,6 +450,10 @@ public class MonumentServiceIntegrationTests {
         assertNull(result.getRandomTagName());
         assertEquals(0, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertNull(result.getMostPopularTagName());
+        assertEquals(0, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -468,6 +472,10 @@ public class MonumentServiceIntegrationTests {
         assertNull(result.getRandomTagName());
         assertEquals(0, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertNull(result.getMostPopularTagName());
+        assertEquals(0, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -488,6 +496,10 @@ public class MonumentServiceIntegrationTests {
         assertNull(result.getRandomTagName());
         assertEquals(0, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertNull(result.getMostPopularTagName());
+        assertEquals(0, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -509,6 +521,10 @@ public class MonumentServiceIntegrationTests {
         assertNull(result.getRandomTagName());
         assertEquals(0, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertNull(result.getMostPopularTagName());
+        assertEquals(0, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -531,6 +547,10 @@ public class MonumentServiceIntegrationTests {
         assertNull(result.getRandomTagName());
         assertEquals(0, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertNull(result.getMostPopularTagName());
+        assertEquals(0, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -543,6 +563,7 @@ public class MonumentServiceIntegrationTests {
 
         Tag tag = new Tag();
         tag.setName("Tag");
+        tag.setIsMaterial(false);
         tag.addMonument(monument);
         this.tagRepository.save(tag);
 
@@ -558,6 +579,10 @@ public class MonumentServiceIntegrationTests {
         assertEquals("Tag", result.getRandomTagName());
         assertEquals(1, result.getNumberOfMonumentsWithRandomTag());
         assertNull(result.getNineElevenMemorialId());
+        assertEquals("Tag", result.getMostPopularTagName());
+        assertEquals(1, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
     }
 
     @Test
@@ -582,11 +607,13 @@ public class MonumentServiceIntegrationTests {
 
         Tag tag1 = new Tag();
         tag1.setName("Tag 1");
+        tag1.setIsMaterial(false);
         tag1.addMonument(monument1);
         this.tagRepository.save(tag1);
 
         Tag tag2 = new Tag();
         tag2.setName("Tag 2");
+        tag2.setIsMaterial(false);
         tag2.addMonument(monument2);
         this.tagRepository.save(tag2);
 
@@ -609,6 +636,153 @@ public class MonumentServiceIntegrationTests {
         assertTrue(usedStates.contains(result.getRandomState()));
         assertTrue(usedTagNames.contains(result.getRandomTagName()));
         assertNull(result.getNineElevenMemorialId());
+        assertNotNull(result.getMostPopularTagName());
+        assertEquals(1, result.getMostPopularTagUses());
+        assertNull(result.getMostPopularMaterialName());
+        assertEquals(0, result.getMostPopularMaterialUses());
+    }
+
+    @Test
+    public void testMonumentService_getMonumentAboutPageStatistics_MostUsedTagAndMaterial_OneOfEach() {
+        Monument monument1 = new Monument();
+        monument1.setTitle("Monument 1");
+        monument1.setDate(new Date());
+        monument1.setState("New York");
+        this.monumentRepository.save(monument1);
+
+        Monument monument2 = new Monument();
+        monument2.setTitle("Monument 2");
+        monument2.setDate(Date.from(ZonedDateTime.now().minusMonths(1).toInstant()));
+        monument2.setState("Rhode Island");
+        this.monumentRepository.save(monument2);
+
+        Monument monument3 = new Monument();
+        monument3.setTitle("Monument 3");
+        monument3.setDate(Date.from(ZonedDateTime.now().minusMonths(3).toInstant()));
+        monument3.setState("Rhode Island");
+        this.monumentRepository.save(monument3);
+
+        Tag tag = new Tag();
+        tag.setName("Tag");
+        tag.setIsMaterial(false);
+        tag.addMonument(monument1);
+        this.tagRepository.save(tag);
+
+        Tag material = new Tag();
+        material.setName("Material");
+        material.setIsMaterial(true);
+        material.addMonument(monument2);
+        this.tagRepository.save(material);
+
+        List<String> usedStates = new ArrayList<>();
+        usedStates.add("New York");
+        usedStates.add("Rhode Island");
+
+        List<String> usedTagNames = new ArrayList<>();
+        usedTagNames.add("Tag");
+        usedTagNames.add("Material");
+
+        MonumentAboutPageStatistics result = this.monumentService.getMonumentAboutPageStatistics(false);
+
+        assertEquals(3, result.getTotalNumberOfMonuments());
+        assertEquals("Monument 3", result.getOldestMonument().getTitle());
+        assertEquals("Monument 1", result.getNewestMonument().getTitle());
+        assertEquals(2, result.getNumberOfMonumentsByState().size());
+        assertEquals(Integer.valueOf(1), result.getNumberOfMonumentsByState().get("New York"));
+        assertEquals(Integer.valueOf(2), result.getNumberOfMonumentsByState().get("Rhode Island"));
+        assertTrue(usedStates.contains(result.getRandomState()));
+        assertTrue(usedTagNames.contains(result.getRandomTagName()));
+        assertNull(result.getNineElevenMemorialId());
+        assertEquals("Tag", result.getMostPopularTagName());
+        assertEquals(1, result.getMostPopularTagUses());
+        assertEquals("Material", result.getMostPopularMaterialName());
+        assertEquals(1, result.getMostPopularMaterialUses());
+    }
+
+    @Test
+    public void testMonumentService_getMonumentAboutPageStatistics_MostUsedTagAndMaterial_VariousAmountsOfEach() {
+        Monument monument1 = new Monument();
+        monument1.setTitle("Monument 1");
+        monument1.setDate(new Date());
+        monument1.setState("New York");
+        this.monumentRepository.save(monument1);
+
+        Monument monument2 = new Monument();
+        monument2.setTitle("Monument 2");
+        monument2.setDate(Date.from(ZonedDateTime.now().minusMonths(1).toInstant()));
+        monument2.setState("Rhode Island");
+        this.monumentRepository.save(monument2);
+
+        Monument monument3 = new Monument();
+        monument3.setTitle("Monument 3");
+        monument3.setDate(Date.from(ZonedDateTime.now().minusMonths(3).toInstant()));
+        monument3.setState("Rhode Island");
+        this.monumentRepository.save(monument3);
+
+        Tag tag1 = new Tag();
+        tag1.setName("Tag 1");
+        tag1.setIsMaterial(false);
+        tag1.addMonument(monument1);
+        this.tagRepository.save(tag1);
+
+        Tag tag2 = new Tag();
+        tag2.setName("Tag 2");
+        tag2.setIsMaterial(false);
+        tag2.addMonument(monument1);
+        tag2.addMonument(monument2);
+        this.tagRepository.save(tag2);
+
+        Tag tag3 = new Tag();
+        tag3.setName("Tag 3");
+        tag3.setIsMaterial(false);
+        this.tagRepository.save(tag3);
+
+        Tag material1 = new Tag();
+        material1.setName("Material 1");
+        material1.setIsMaterial(true);
+        material1.addMonument(monument2);
+        this.tagRepository.save(material1);
+
+        Tag material2 = new Tag();
+        material2.setName("Material 2");
+        material2.setIsMaterial(true);
+        this.tagRepository.save(material2);
+
+        Tag material3 = new Tag();
+        material3.setName("Material 3");
+        material3.setIsMaterial(true);
+        material3.addMonument(monument1);
+        material3.addMonument(monument2);
+        material3.addMonument(monument3);
+        this.tagRepository.save(material3);
+
+        List<String> usedStates = new ArrayList<>();
+        usedStates.add("New York");
+        usedStates.add("Rhode Island");
+
+        List<String> usedTagNames = new ArrayList<>();
+        usedTagNames.add("Tag 1");
+        usedTagNames.add("Tag 2");
+        usedTagNames.add("Tag 3");
+        usedTagNames.add("Material 1");
+        usedTagNames.add("Material 2");
+        usedTagNames.add("Material 3");
+
+        MonumentAboutPageStatistics result = this.monumentService.getMonumentAboutPageStatistics(false);
+
+        assertEquals(3, result.getTotalNumberOfMonuments());
+        assertEquals("Monument 3", result.getOldestMonument().getTitle());
+        assertEquals("Monument 1", result.getNewestMonument().getTitle());
+        assertEquals(2, result.getNumberOfMonumentsByState().size());
+        assertEquals(Integer.valueOf(1), result.getNumberOfMonumentsByState().get("New York"));
+        assertEquals(Integer.valueOf(2), result.getNumberOfMonumentsByState().get("Rhode Island"));
+        assertTrue(usedStates.contains(result.getRandomState()));
+        assertTrue(usedTagNames.contains(result.getRandomTagName()));
+        assertNull(result.getNineElevenMemorialId());
+        assertEquals("Tag 2", result.getMostPopularTagName());
+        assertEquals(2, result.getMostPopularTagUses());
+        assertEquals("Material 3", result.getMostPopularMaterialName());
+        assertEquals(3, result.getMostPopularMaterialUses());
     }
 
     /* updateMonumentReferences Tests **/

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
@@ -175,7 +175,7 @@ public class MonumentServiceMockIntegrationTests {
 
     @Test
     public void testMonumentService_BulkCreateFlow_OneInvalidCsvRecord() {
-        String csvRow = "Test Submitted By,Test Artist,,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000,180.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
+        String csvRow = "Test Submitted By,Test Artist,,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000°,180.000°,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
 
         // validateMonumentCSV
         MonumentBulkValidationResult validationResult = this.validateCSV(csvRow);
@@ -185,6 +185,9 @@ public class MonumentServiceMockIntegrationTests {
         assertEquals(1, validationResult.getInvalidResults().size());
 
         CsvMonumentConverterResult validationErrors = validationResult.getInvalidResults().get(1);
+
+        assertEquals(3, validationErrors.getWarnings().size());
+        assertTrue(validationErrors.getWarnings().contains("Please use decimal coordinates, not degrees. To convert, input your degrees into Google Maps."));
 
         assertEquals(2, validationErrors.getErrors().size());
         assertTrue(validationErrors.getErrors().contains("Title is required"));
@@ -209,7 +212,7 @@ public class MonumentServiceMockIntegrationTests {
 
     @Test
     public void testMonumentService_BulkCreateFlow_OneValidRecord() {
-        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000,180.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com,";
+        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,40.730610,-73.935242,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com,";
 
         // validateMonumentCSV
         MonumentBulkValidationResult validationResult = this.validateCSV(csvRow);
@@ -254,13 +257,17 @@ public class MonumentServiceMockIntegrationTests {
         assertEquals(2, validationResult.getInvalidResults().size());
 
         CsvMonumentConverterResult validationErrorsRow1 = validationResult.getResults().get(1);
-        assertEquals(2, validationErrorsRow1.getErrors().size());
+        assertEquals(4, validationErrorsRow1.getErrors().size());
         assertTrue(validationErrorsRow1.getErrors().contains("Title is required"));
         assertTrue(validationErrorsRow1.getErrors().contains("All References must be valid URLs"));
+        assertTrue(validationErrorsRow1.getErrors().contains("Latitude is not near the United States"));
+        assertTrue(validationErrorsRow1.getErrors().contains("Longitude is not near the United States"));
 
         CsvMonumentConverterResult validationErrorsRow2 = validationResult.getInvalidResults().get(2);
-        assertEquals(1, validationErrorsRow2.getErrors().size());
+        assertEquals(3, validationErrorsRow2.getErrors().size());
         assertTrue(validationErrorsRow2.getErrors().contains("At least one Material is required"));
+        assertTrue(validationErrorsRow2.getErrors().contains("Latitude is not near the United States"));
+        assertTrue(validationErrorsRow2.getErrors().contains("Longitude is not near the United States"));
 
         // parseMonumentBulkValidationResult
         BulkCreateMonumentSuggestion bulkCreateSuggestionResult = this.monumentServiceMock.parseMonumentBulkValidationResultSync(validationResult);
@@ -281,7 +288,7 @@ public class MonumentServiceMockIntegrationTests {
 
     @Test
     public void testMonumentService_BulkCreateFlow_TwoValidRecords() {
-        String csvRows = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000,180.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
+        String csvRows = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,40.730610,-73.935242,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
                 "\n,Test Artist,Test Title,,\"Material 1, Material 2\",,,,,,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com,";
 
         // validateMonumentCSV
@@ -316,7 +323,7 @@ public class MonumentServiceMockIntegrationTests {
 
     @Test
     public void testMonumentService_BulkCreateFlow_MixedValidAndInvalidRows() {
-        String csvRows = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000,180.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
+        String csvRows = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,40.730610,-73.935242,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
                 "\nTest Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,93.000,184.000,Test City,Test State,,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
                 "\n,Test Artist,Test Title,,\"Material 1, Material 2\",,,,,,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com," +
                 "\n,Test Artist,,,,,,,,,Test Address,\"Tag 1, Tag 2, Tag 3\",http://test.com,";
@@ -329,9 +336,11 @@ public class MonumentServiceMockIntegrationTests {
         assertEquals(2, validationResult.getInvalidResults().size());
 
         CsvMonumentConverterResult validationErrorsRow2 = validationResult.getInvalidResults().get(2);
-        assertEquals(2, validationErrorsRow2.getErrors().size());
+        assertEquals(4, validationErrorsRow2.getErrors().size());
         assertTrue(validationErrorsRow2.getErrors().contains("Latitude must be valid"));
         assertTrue(validationErrorsRow2.getErrors().contains("Longitude must be valid"));
+        assertTrue(validationErrorsRow2.getErrors().contains("Latitude is not near the United States"));
+        assertTrue(validationErrorsRow2.getErrors().contains("Longitude is not near the United States"));
 
         CsvMonumentConverterResult validationErrorsRow4 = validationResult.getInvalidResults().get(4);
         assertEquals(2, validationErrorsRow4.getErrors().size());

--- a/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterUnitTests.java
+++ b/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterUnitTests.java
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -314,7 +313,7 @@ public class CsvMonumentConverterUnitTests {
 
     @Test
     public void testCsvMonumentConverter_convertCsvRow_VariousValues_LatitudeAndLongitude() {
-        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,90.000,180.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
+        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,40.730610,-73.935242,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
         List<String[]> csvList = MonumentServiceMockIntegrationTests.parseCSVString(csvRow);
 
         CsvMonumentConverterResult result = CsvMonumentConverter.convertCsvRows(csvList, mapping, null).get(0);
@@ -330,8 +329,8 @@ public class CsvMonumentConverterUnitTests {
         assertEquals("Test Title", suggestionResult.getTitle());
         assertEquals("12-03-1997", suggestionResult.getDate());
         assertEquals("Test Inscription", suggestionResult.getInscription());
-        assertEquals(90.000, suggestionResult.getLatitude(), 0.0);
-        assertEquals(180.000, suggestionResult.getLongitude(), 0.0);
+        assertEquals(40.730610, suggestionResult.getLatitude(), 0.0);
+        assertEquals(-73.935242, suggestionResult.getLongitude(), 0.0);
         assertEquals("Test City", suggestionResult.getCity());
         assertEquals("Test State", suggestionResult.getState());
         assertEquals("Test Address", suggestionResult.getAddress());
@@ -344,7 +343,7 @@ public class CsvMonumentConverterUnitTests {
     }
 
     @Test
-    public void testCsvMonumentConverter_convertCsvRow_VariousValues_InvalidLatitudeAndLongitude() {
+    public void testCsvMonumentConverter_convertCsvRow_VariousValues_InvalidLatitudeAndLongitude_NotValidNumbers() {
         String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,lat,lon,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
         List<String[]> csvList = MonumentServiceMockIntegrationTests.parseCSVString(csvRow);
 
@@ -373,6 +372,70 @@ public class CsvMonumentConverterUnitTests {
 
         assertEquals(2, result.getWarnings().size());
         assertEquals(1, result.getErrors().size());
+    }
+
+    @Test
+    public void testCsvMonumentConverter_convertCsvRow_VariousValues_InvalidLatitudeAndLongitude_DegreesFormat() {
+        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,40.730°,-73.935°,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
+        List<String[]> csvList = MonumentServiceMockIntegrationTests.parseCSVString(csvRow);
+
+        CsvMonumentConverterResult result = CsvMonumentConverter.convertCsvRows(csvList, mapping, null).get(0);
+        CreateMonumentSuggestion suggestionResult = result.getMonumentSuggestion();
+        Set<String> materialNameResults = result.getMaterialNames();
+        Set<String> tagNameResults = result.getTagNames();
+
+        assertEquals(1, result.getContributorNames().size());
+        assertEquals(1, result.getReferenceUrls().size());
+        assertEquals(0, result.getImageFiles().size());
+
+        assertEquals("Test Artist", suggestionResult.getArtist());
+        assertEquals("Test Title", suggestionResult.getTitle());
+        assertEquals("12-03-1997", suggestionResult.getDate());
+        assertEquals("Test Inscription", suggestionResult.getInscription());
+        assertEquals("Test City", suggestionResult.getCity());
+        assertEquals("Test State", suggestionResult.getState());
+        assertEquals("Test Address", suggestionResult.getAddress());
+
+        assertNull(suggestionResult.getLatitude());
+        assertNull(suggestionResult.getLongitude());
+
+        assertEquals(2, materialNameResults.size());
+        assertEquals(3, tagNameResults.size());
+
+        assertEquals(3, result.getWarnings().size());
+        assertEquals(1, result.getErrors().size());
+    }
+
+    @Test
+    public void testCsvMonumentConverter_convertCsvRow_VariousValues_InvalidLatitudeAndLongitude_NotNearTheUS() {
+        String csvRow = "Test Submitted By,Test Artist,Test Title,12-03-1997,\"Material 1, Material 2\",Test Inscription,73.000,-62.000,Test City,Test State,Test Address,\"Tag 1, Tag 2, Tag 3\",Test Reference,";
+        List<String[]> csvList = MonumentServiceMockIntegrationTests.parseCSVString(csvRow);
+
+        CsvMonumentConverterResult result = CsvMonumentConverter.convertCsvRows(csvList, mapping, null).get(0);
+        CreateMonumentSuggestion suggestionResult = result.getMonumentSuggestion();
+        Set<String> materialNameResults = result.getMaterialNames();
+        Set<String> tagNameResults = result.getTagNames();
+
+        assertEquals(1, result.getContributorNames().size());
+        assertEquals(1, result.getReferenceUrls().size());
+        assertEquals(0, result.getImageFiles().size());
+
+        assertEquals("Test Artist", suggestionResult.getArtist());
+        assertEquals("Test Title", suggestionResult.getTitle());
+        assertEquals("12-03-1997", suggestionResult.getDate());
+        assertEquals("Test Inscription", suggestionResult.getInscription());
+        assertEquals("Test City", suggestionResult.getCity());
+        assertEquals("Test State", suggestionResult.getState());
+        assertEquals("Test Address", suggestionResult.getAddress());
+
+        assertEquals(73.000, suggestionResult.getLatitude(), 0.0);
+        assertEquals(-62.000, suggestionResult.getLongitude(), 0.0);
+
+        assertEquals(2, materialNameResults.size());
+        assertEquals(3, tagNameResults.size());
+
+        assertEquals(0, result.getWarnings().size());
+        assertEquals(3, result.getErrors().size());
     }
 
     @Test


### PR DESCRIPTION
This PR:

- Adds an extra error message for Coordinates in DMS format for Create and Bulk-Create

**Create Screenshot:**
![Coordinates DMS Format Warning](https://user-images.githubusercontent.com/16584007/79668911-0eac6000-8186-11ea-9aad-41493830f9ad.PNG)

**Bulk-Create Screenshot:**
![Coordinates DMS Format Warning Bulk-Create](https://user-images.githubusercontent.com/16584007/79668924-1ff56c80-8186-11ea-8c5e-84af77d5ab25.PNG)

- Enforces the maximum image file size limit of 5MB for Create and Bulk-Create

**Create Screenshot:**
![Create and Update File Size Too Large](https://user-images.githubusercontent.com/16584007/79668944-3d2a3b00-8186-11ea-99e8-d8d85514d7f9.PNG)

**Bulk-Create Screenshot:**
![Bulk-Create File Size Too Large](https://user-images.githubusercontent.com/16584007/79668949-41eeef00-8186-11ea-98b2-5b90542522f0.PNG)

- Fixes the TagsSearch Component so duplicate Tags/Materials are no longer created
- Adds the most used Tag and Material as Statistic Cards to the About Page

**Screenshot (the text should be green in this picture, it's from before I made the text links):**
![Most Popular Tag and Material About Page](https://user-images.githubusercontent.com/16584007/79668973-677bf880-8186-11ea-9bdf-0b8ffd96c752.PNG)

- Fixes the Page centering on the Create and Update Pages
- Fixes potential `ArrayIndexOutOfBoundsException`s when performing geocoding and reverse geocoding
- Adds an error message when the specified Coordinates are not near the United States for Create and Bulk-Create
- Fixes broken duplicate monument links during Create

**EDIT:**
I also fixed all other usages of the `SearchResults` and `SearchResult` component so that they default to using `/monuments` as the `monumentUri` and no longer link to an undefined page (was causing the Favorites bug Dr. Decker brought up recently).