### PR TITLE
Add geocoding/reverse geocoding to create/update UI

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -135,11 +135,6 @@ h1, .h1 {
     }
 }
 
-.modal-dialog.update-review-modal-dialog {
-    width: 60vw;
-    max-width: none !important;
-}
-
 .card-header {
     background-color: rgba(0,0,0,0) !important;
     border-bottom: 0 !important;

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -514,8 +514,6 @@ export default class CreateOrUpdateForm extends React.Component {
             newState: state
         };
 
-        console.log(updateForm);
-
         switch (dateSelectValue) {
             case 'year':
                 updateForm.newYear = year.value === '' ? undefined : year.value;
@@ -656,7 +654,6 @@ export default class CreateOrUpdateForm extends React.Component {
         }
         address = result.formatted_address;
         this.setState({city, state, address: {...this.state.address, value: address}});
-        console.log({city, state, address: {...this.state.address, value: address}});
     }
 
     handleAdvancedInformationClick() {
@@ -986,7 +983,7 @@ export default class CreateOrUpdateForm extends React.Component {
         const { showingAdvancedInformation, dateSelectValue, datePickerCurrentDate, title, address, latitude,
             longitude, year, month, artist, description, inscription, references, imageUploaderKey, materials,
             imagesForUpdate, isTemporary, locationType, photoSphereImagesForUpdate, photoSphereImages,
-            city, state} = this.state;
+            city, state } = this.state;
         const { monument, action } = this.props;
 
         const advancedInformationLink = (

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -200,7 +200,7 @@ export default class CreateOrUpdateForm extends React.Component {
         const { title, address, latitude, longitude, year, month, artist, description, inscription,
             materials, locationType } = this.state;
         let { datePickerCurrentDate, references, tags, imagesForUpdate, photoSphereImagesForUpdate, images,
-            photoSphereImages, imageUploaderKey } = this.state;
+            photoSphereImages, imageUploaderKey, city, state } = this.state;
 
         let monumentYear, monumentMonth, monumentExactDate;
 
@@ -225,6 +225,8 @@ export default class CreateOrUpdateForm extends React.Component {
         year.value = monumentYear ? monumentYear : '';
         month.value = monumentMonth ? monumentMonth : '';
         datePickerCurrentDate = monumentExactDate ? monumentExactDate : new Date();
+        city = monument.city;
+        state = monument.state;
 
         if (address.value) locationType.value = 'address';
         else if (latitude.value && longitude.value) locationType.value = 'coordinates';
@@ -292,7 +294,7 @@ export default class CreateOrUpdateForm extends React.Component {
 
         this.setState({title, address, latitude, longitude, artist, description, inscription, year, month,
             datePickerCurrentDate, references, materials, tags, imagesForUpdate, photoSphereImagesForUpdate, images,
-            photoSphereImages, imageUploaderKey, locationType});
+            photoSphereImages, imageUploaderKey, locationType, city, state});
     }
 
     /**
@@ -438,7 +440,7 @@ export default class CreateOrUpdateForm extends React.Component {
     buildCreateForm() {
         const { title, address, latitude, longitude, dateSelectValue, year, month, artist, description, inscription,
             datePickerCurrentDate, references, images, photoSphereImages, materials, newMaterials, tags, newTags,
-            isTemporary } = this.state;
+            isTemporary, city, state } = this.state;
 
         let createForm = {
             title: title.value,
@@ -456,7 +458,9 @@ export default class CreateOrUpdateForm extends React.Component {
             tags: tags.map(tag => tag.name),
             newTags: newTags.map(newTag => newTag.name),
             dateSelectValue: dateSelectValue,
-            isTemporary: isTemporary.value
+            isTemporary: isTemporary.value,
+            city,
+            state
         };
 
         switch (dateSelectValue) {
@@ -490,7 +494,7 @@ export default class CreateOrUpdateForm extends React.Component {
     buildUpdateForm() {
         const { title, address, artist, description, inscription, latitude, longitude, dateSelectValue, year, month,
             datePickerCurrentDate, references, images, imagesForUpdate, photoSphereImages, photoSphereImagesForUpdate,
-            materials, tags, isTemporary } = this.state;
+            materials, tags, isTemporary, city, state } = this.state;
         let { newMaterials, newTags } = this.state;
 
         let updateForm = {
@@ -505,8 +509,12 @@ export default class CreateOrUpdateForm extends React.Component {
             photoSphereImages: photoSphereImages.map(photoSphereImage => photoSphereImage.url),
             newIsTemporary: isTemporary.value,
             dateSelectValue: dateSelectValue,
-            imagesForUpdate: imagesForUpdate
+            imagesForUpdate: imagesForUpdate,
+            newCity: city,
+            newState: state
         };
+
+        console.log(updateForm);
 
         switch (dateSelectValue) {
             case 'year':
@@ -648,6 +656,7 @@ export default class CreateOrUpdateForm extends React.Component {
         }
         address = result.formatted_address;
         this.setState({city, state, address: {...this.state.address, value: address}});
+        console.log({city, state, address: {...this.state.address, value: address}});
     }
 
     handleAdvancedInformationClick() {
@@ -1119,7 +1128,7 @@ export default class CreateOrUpdateForm extends React.Component {
         }
 
         return (
-            <div className="create-form-container">
+            <div className="create-form">
                 {monument
                     ? <div className="h4 update">{action} an existing Monument or Memorial</div>
                     : <div className="h4 create">{action} a new Monument or Memorial</div>}
@@ -1377,30 +1386,32 @@ export default class CreateOrUpdateForm extends React.Component {
                         </div>
                     </Collapse>
 
-                    {!showingAdvancedInformation && advancedInformationLink}
-                    {showingAdvancedInformation && hideAdvancedInformationLink}
+                    <div className="d-flex flex-column justify-content-center">
+                        {!showingAdvancedInformation && advancedInformationLink}
+                        {showingAdvancedInformation && hideAdvancedInformationLink}
 
-                    <ButtonToolbar className={monument ? 'btn-toolbar update' : null}>
-                        <Button
-                            variant="primary"
-                            type="submit"
-                            className="mr-4 mt-1"
-                        >
-                            Submit
-                        </Button>
+                        <ButtonToolbar className={monument ? 'btn-toolbar update' : null}>
+                            <Button
+                                variant="primary"
+                                type="submit"
+                                className="mr-4 mt-1"
+                            >
+                                Submit
+                            </Button>
 
-                        {this.renderClearButton()}
-                        {this.renderResetButton()}
+                            {this.renderClearButton()}
+                            {this.renderResetButton()}
 
-                        <Button
-                            variant="danger"
-                            type="button"
-                            onClick={() => this.handleCancelButtonClick()}
-                            className="mt-1"
-                        >
-                            Cancel
-                        </Button>
-                    </ButtonToolbar>
+                            <Button
+                                variant="danger"
+                                type="button"
+                                onClick={() => this.handleCancelButtonClick()}
+                                className="mt-1"
+                            >
+                                Cancel
+                            </Button>
+                        </ButtonToolbar>
+                    </div>
                 </Form>
             </div>
         );

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
@@ -237,7 +237,6 @@
     }
 
     .images-for-update-container {
-        margin-top: -3rem;
         display: flex;
 
         .image-for-update-container {

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
@@ -1,6 +1,7 @@
 @import "../../theme";
 
-.create-form-container {
+.create-form {
+    max-width: 390px;
     .h4 {
         padding-bottom: 1rem;
         text-align: center;
@@ -60,14 +61,7 @@
         padding-bottom: 1rem;
         font-weight: bold;
         text-decoration: underline;
-
-        &.more-link {
-            padding-left: 9.75rem;
-        }
-
-        &.hide-link {
-            padding-left: 9rem;
-        }
+        text-align: center;
     }
 
     .address-coordinates-container {
@@ -135,7 +129,6 @@
     }
 
     .fileUploader {
-        width: 25rem;
 
         .fileContainer {
             box-shadow: none;
@@ -147,7 +140,7 @@
                 font-weight: bold;
                 text-transform: uppercase;
                 font-family: "Open Sans", sans-serif;
-                margin: 0 0 10px 50px;
+                margin: 0;
 
                 &:hover {
                     background-color: #389c6f;

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.scss
@@ -71,9 +71,7 @@
     }
 
     .address-coordinates-container {
-        border-style: solid;
-        border-color: lightgray;
-        border-width: thin;
+        border: 1px solid lightgray;
         padding: 1.0rem 1.5rem 1.5rem 1.5rem;
         width: 30rem;
         margin-bottom: 1rem;
@@ -89,13 +87,16 @@
 
         .coordinates-group {
             display: flex;
+
             .coordinate-field {
                 flex-basis: 50%;
                 display: flex;
                 flex-direction: column;
+
                 &:first-child {
                     margin-right: 0.5rem;
                 }
+
                 .form-control {
                     width: 100%;
                 }
@@ -312,6 +313,18 @@
         &.undo {
             background: $secondary;
             z-index: 2;
+        }
+    }
+
+    .coordinates-geocode-group {
+        border: 1px solid lightgray;
+        background-color: rgba(10, 20, 50, 0.01);
+        padding: 1rem;
+        margin-top: 1rem;
+
+        .coordinates-geocode-row-label {
+            display: inline;
+            font-weight: 500;
         }
     }
 

--- a/client/src/components/CreateOrUpdateForm/PhotoSphereImages/PhotoSphereImages.js
+++ b/client/src/components/CreateOrUpdateForm/PhotoSphereImages/PhotoSphereImages.js
@@ -170,7 +170,7 @@ export default class PhotoSphereImages extends React.Component {
                 <Button variant="link" className="pl-0" onClick={() => this.setState({modalShowing: true})}>
                     How do I find 360° images?
                 </Button>
-                <div>
+                <div className="add-photosphere-group d-flex">
                     <Form.Control
                         type="text"
                         name="add-photosphere"
@@ -178,10 +178,10 @@ export default class PhotoSphereImages extends React.Component {
                         value={linkInput.value}
                         onChange={event => this.handleInputChange(event)}
                         isInvalid={!linkInput.isValid}
-                        className="text-control d-inline-block"
+                        className="text-control d-inline-block mr-3"
                     />
                     <Button disabled={!linkInput.value || !linkInput.isValid}
-                            className="ml-3 text-uppercase d-inline-block"
+                            className="text-uppercase d-inline-block"
                             onClick={() => this.handleAddImage()}>
                         Add 360° Image
                     </Button>

--- a/client/src/components/CreateOrUpdateForm/PhotoSphereImages/PhotoSphereImages.scss
+++ b/client/src/components/CreateOrUpdateForm/PhotoSphereImages/PhotoSphereImages.scss
@@ -18,6 +18,12 @@
     }
 }
 
+.add-photosphere-group {
+    .btn {
+        white-space: nowrap;
+    }
+}
+
 @keyframes overlay-appear {
     0% {
         opacity: 0;

--- a/client/src/components/Header/SearchBar/LocationSearch/LocationSearch.js
+++ b/client/src/components/Header/SearchBar/LocationSearch/LocationSearch.js
@@ -43,15 +43,12 @@ export default class LocationSearch extends React.Component {
         this.setState({searchQuery: newSearchQuery});
     }
 
-    handleSelect(address) {
+    async handleSelect(address) {
         const { onSuggestionSelect } = this.props;
 
-        geocodeByAddress(address)
-            .then(results => getLatLng(results[0]))
-            .then(latLon => {
-                onSuggestionSelect(latLon.lat.toFixed(6), latLon.lng.toFixed(6), address);
-            })
-            .catch(error => console.error("Error", error));
+        const results = await geocodeByAddress(address);
+        const latLon = await getLatLng(results[0]);
+        onSuggestionSelect(latLon.lat.toFixed(6), latLon.lng.toFixed(6), address, results[0]);
     }
 
     handleClear() {

--- a/client/src/components/Monument/Details/About/About.js
+++ b/client/src/components/Monument/Details/About/About.js
@@ -161,16 +161,19 @@ export default class About extends React.Component {
 
         let contributorsList;
         if (contributions && contributions.length) {
+            let contributors = contributions.map(contribution => {
+                if (contribution.submittedByUser) {
+                    contribution.submittedBy = getUserFullName(contribution.submittedByUser);
+                }
+                return contribution.submittedBy;
+            });
+            // Remove any duplicates
+            contributors = contributors.filter((contributor, index) => contributors.indexOf(contributor) === index);
             contributorsList = (
                 <div>
                     <span className="detail-label">Contributors:&nbsp;</span>
                     <ul>
-                        {contributions.map(contribution => {
-                            if (contribution.submittedByUser) {
-                                contribution.submittedBy = getUserFullName(contribution.submittedByUser);
-                            }
-                            return (<li key={contribution.id}>{contribution.submittedBy}</li>);
-                        })}
+                        {contributors.map(contributor => (<li key={contributor.id}>{contributor}</li>))}
                     </ul>
                 </div>
             )

--- a/client/src/components/Monument/Details/Details.scss
+++ b/client/src/components/Monument/Details/Details.scss
@@ -1,6 +1,17 @@
+@import "../../../../node_modules/bootstrap/scss/functions";
+@import "../../../../node_modules/bootstrap/scss/variables";
+@import "../../../../node_modules/bootstrap/scss/mixins";
 @import "../../../theme";
 
+.main-column {
+    width: 100%;
+}
 .details {
+    width: 100%;
+    @include media-breakpoint-up(md) {
+        min-width: 500px;
+        width: auto;
+    }
     .favorite-icon {
         transform: translateY(-14px);
         cursor: pointer;

--- a/client/src/components/Monument/Update/MonumentUpdate.js
+++ b/client/src/components/Monument/Update/MonumentUpdate.js
@@ -299,8 +299,8 @@ export default class MonumentUpdate extends React.Component {
 
             /* State */
             (this.didAttributeChange(oldMonument.state, update.newState)) ?
-                changedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.state} newAttribute={update.newState} key="state"/>) :
-                unchangedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.state} newAttribute={update.newState} didChange={false} key="state"/>);
+                changedAttributes.push(<AttributeChange attributeLabel="State" oldAttribute={oldMonument.state} newAttribute={update.newState} key="state"/>) :
+                unchangedAttributes.push(<AttributeChange attributeLabel="State" oldAttribute={oldMonument.state} newAttribute={update.newState} didChange={false} key="state"/>);
 
             /* Latitude */
             let oldLatitude = oldMonument.lat ? oldMonument.lat.toString() : '';

--- a/client/src/components/Monument/Update/MonumentUpdate.js
+++ b/client/src/components/Monument/Update/MonumentUpdate.js
@@ -292,6 +292,16 @@ export default class MonumentUpdate extends React.Component {
                 changedAttributes.push(<AttributeChange attributeLabel="Address" oldAttribute={oldMonument.address} newAttribute={update.newAddress} key="address"/>) :
                 unchangedAttributes.push(<AttributeChange attributeLabel="Address" oldAttribute={oldMonument.address} newAttribute={update.newAddress} didChange={false} key="address"/>);
 
+            /* City */
+            (this.didAttributeChange(oldMonument.city, update.newCity)) ?
+                changedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.city} newAttribute={update.newCity} key="city"/>) :
+                unchangedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.city} newAttribute={update.newCity} didChange={false} key="city"/>);
+
+            /* State */
+            (this.didAttributeChange(oldMonument.state, update.newState)) ?
+                changedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.state} newAttribute={update.newState} key="state"/>) :
+                unchangedAttributes.push(<AttributeChange attributeLabel="City" oldAttribute={oldMonument.state} newAttribute={update.newState} didChange={false} key="state"/>);
+
             /* Latitude */
             let oldLatitude = oldMonument.lat ? oldMonument.lat.toString() : '';
             (this.didAttributeChange(oldLatitude, update.newLatitude)) ?

--- a/client/src/components/ReviewModal/CreateReviewModal/CreateReviewModal.js
+++ b/client/src/components/ReviewModal/CreateReviewModal/CreateReviewModal.js
@@ -111,14 +111,15 @@ export default class CreateReviewModal extends React.Component {
             <Modal
                 show={showing}
                 onHide={onCancel}
+                className="create-review-modal"
             >
-                <Modal.Header className="create-review-modal">
+                <Modal.Header>
                     <Modal.Title>
                         Review Creation
                     </Modal.Title>
                 </Modal.Header>
-                <hr className="create-review-modal"/>
-                <Modal.Body className="create-review-modal">
+                <hr/>
+                <Modal.Body>
                     <p>Please review the data you entered for correctness and completeness!</p>
                     <p>*Fields marked with an asterisk are required.</p>
                     <p>**Address OR Latitude AND Longitude are required.</p>
@@ -160,6 +161,18 @@ export default class CreateReviewModal extends React.Component {
                             )}
                         </div>
                         <div className="attribute">
+                            <span className="font-weight-bold">City:&nbsp;</span>
+                            {form.city ? form.city : (
+                                <span className="missing-attribute">NONE</span>
+                            )}
+                        </div>
+                        <div className="attribute">
+                            <span className="font-weight-bold">State:&nbsp;</span>
+                            {form.state ? form.state : (
+                                <span className="missing-attribute">NONE</span>
+                            )}
+                        </div>
+                        <div className="attribute">
                             <span className="font-weight-bold">Description:&nbsp;</span>
                             {form.description ? form.description : (
                                 <span className="missing-attribute">NONE</span>
@@ -193,7 +206,7 @@ export default class CreateReviewModal extends React.Component {
                         </div>
                     </div>
                 </Modal.Body>
-                <Modal.Footer className="create-review-modal">
+                <Modal.Footer>
                     <Button
                         variant="danger"
                         onClick={onCancel}

--- a/client/src/components/ReviewModal/CreateReviewModal/CreateReviewModal.scss
+++ b/client/src/components/ReviewModal/CreateReviewModal/CreateReviewModal.scss
@@ -1,61 +1,68 @@
-.modal-content {
-  .create-review-modal {
-    &.modal-header {
-      padding-bottom: 0;
-
-      .modal-title {
-        color: #61616D;
-        font-size: x-large;
-      }
+.create-review-modal {
+    .modal-dialog {
+        width: 60vw;
+        max-width: 60vw;
     }
 
-    &.modal-footer {
-      border-top: 2px solid #dee2e6;
-
-      .btn {
-        font-weight: bold;
-        text-transform: uppercase;
-        font-family: "Open Sans", sans-serif;
-      }
+    hr {
+        width: 100%;
+        border-top: 2px solid rgba(0, 0, 0, 0.1);
+        margin-bottom: 0;
     }
 
-    &.modal-body {
-      padding: 0.25rem 1rem 0.25rem 1rem;
+    .modal-header {
+        padding-bottom: 0;
 
-      p {
-        padding-top: 0.5rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .attributes-container {
-        border: thin solid;
-        background-color: lightgray;
-        padding: 0.5rem;
-
-        .missing-attribute {
-          font-weight: bold;
-          color: red;
+        .modal-title {
+            color: #61616D;
+            font-size: x-large;
         }
-
-        ul {
-          margin-bottom: 0;
-        }
-
-        iframe {
-          height: 300px;
-          margin-bottom: 1rem;
-        }
-
-        iframe:last-child {
-          margin-bottom: 0;
-        }
-      }
     }
-  }
 
-  hr.create-review-modal {
-    width: 100%;
-    border-top: 2px solid rgba(0, 0, 0, 0.1);
-    margin-bottom: 0;
-  }
+    .modal-footer {
+        border-top: 2px solid #dee2e6;
+
+        .btn {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-family: "Open Sans", sans-serif;
+        }
+    }
+
+    .modal-body {
+        padding: 0.25rem 1rem 0.25rem 1rem;
+
+        p {
+            padding-top: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .attribute {
+            white-space: normal;
+        }
+
+        .attributes-container {
+            border: thin solid;
+            background-color: lightgray;
+            padding: 0.5rem;
+
+            .missing-attribute {
+                font-weight: bold;
+                color: red;
+            }
+
+            ul {
+                margin-bottom: 0;
+            }
+
+            iframe {
+                height: 300px;
+                margin-bottom: 1rem;
+            }
+
+            iframe:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
 }

--- a/client/src/components/ReviewModal/UpdateReviewModal/UpdateReviewModal.js
+++ b/client/src/components/ReviewModal/UpdateReviewModal/UpdateReviewModal.js
@@ -36,18 +36,18 @@ export default class UpdateReviewModal extends React.Component {
                 onHide={onCancel}
                 dialogClassName="update-review-modal-dialog"
             >
-                <Modal.Header className="update-review-modal">
+                <Modal.Header>
                     <Modal.Title>
                         Review Update
                     </Modal.Title>
                 </Modal.Header>
-                <Modal.Body className="update-review-modal">
+                <Modal.Body>
                     <p>Please review the updates you have made for correctness and completeness!</p>
                     <div className="attributes-update-container">
                         <MonumentUpdate oldMonument={oldMonument} update={this.buildUpdate()}/>
                     </div>
                 </Modal.Body>
-                <Modal.Footer className="update-review-modal">
+                <Modal.Footer>
                     <Button
                         variant="danger"
                         onClick={onCancel}

--- a/client/src/components/ReviewModal/UpdateReviewModal/UpdateReviewModal.scss
+++ b/client/src/components/ReviewModal/UpdateReviewModal/UpdateReviewModal.scss
@@ -1,51 +1,50 @@
 @import "../../../theme";
 
-.modal-content {
-  min-width: fit-content;
+.update-review-modal-dialog {
+    width: 60vw;
+    max-width: 60vw !important;
 
-  .update-review-modal {
-    &.modal-header {
-      padding-bottom: 0;
-      border-bottom: 2px solid #DEE2E6;
+    .modal-header {
+        padding-bottom: 0;
+        border-bottom: 2px solid #DEE2E6;
 
-      .modal-title {
-        color: #61616D;
-        font-size: x-large;
-      }
-    }
-
-    &.modal-body {
-      padding: 0.25rem 1rem 0.5rem 1rem;
-      overflow: hidden;
-      white-space: normal;
-
-      p {
-        padding-top: 0.5rem;
-        margin-bottom: 0.5rem;
-        text-align: center;
-        font-size: 14px;
-      }
-
-      .attributes-update-container {
-        border: thin solid;
-        background-color: lightgray;
-        padding: 0.5rem;
-        font-size: medium;
-
-        i {
-          font-size: 36px;
+        .modal-title {
+            color: #61616D;
+            font-size: x-large;
         }
-      }
     }
 
-    &.modal-footer {
-      border-top: 2px solid #DEE2E6;
+    .modal-body {
+        padding: 0.25rem 1rem 0.5rem 1rem;
+        overflow: hidden;
+        white-space: normal;
 
-      .btn {
-        font-weight: bold;
-        text-transform: uppercase;
-        font-family: "Open Sans", sans-serif;
-      }
+        p {
+            padding-top: 0.5rem;
+            margin-bottom: 0.5rem;
+            text-align: center;
+            font-size: 14px;
+        }
+
+        .attributes-update-container {
+            border: thin solid;
+            background-color: lightgray;
+            padding: 0.5rem;
+            font-size: medium;
+
+            i {
+                font-size: 36px;
+            }
+        }
     }
-  }
+
+    .modal-footer {
+        border-top: 2px solid #DEE2E6;
+
+        .btn {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-family: "Open Sans", sans-serif;
+        }
+    }
 }

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.js
@@ -185,18 +185,16 @@ class CreateMonumentPage extends React.Component {
         }
 
         return (
-            <div className="create-page-container">
+            <div className="create page">
                 <Helmet title="Create | Monuments and Memorials"/>
                 <Spinner show={createCreateSuggestionPending || fetchDuplicatesPending || pending || createMonumentPending}/>
-                <div className="column left"/>
-                <div className="column form-column">
+                <div className="create-form-container">
                     <CreateOrUpdateForm
                         onCancelButtonClick={() => this.handleCreateFormCancelButtonClick()}
                         onSubmit={(form) => this.handleCreateFormSubmit(form)}
                         action={action}
                     />
                 </div>
-                <div className="column"/>
 
                 {this.renderDuplicateMonuments()}
                 {this.renderNoImageModal()}

--- a/client/src/pages/CreateMonumentPage/CreateMonumentPage.scss
+++ b/client/src/pages/CreateMonumentPage/CreateMonumentPage.scss
@@ -2,11 +2,12 @@
 @import "../../../node_modules/bootstrap/scss/variables";
 @import "../../../node_modules/bootstrap/scss/mixins";
 
-.create-page-container {
+.create-form-container {
   min-width: 100%;
   margin: 0;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   height: 100%;
 
   .column {

--- a/src/main/java/com/monumental/models/suggestions/UpdateMonumentSuggestion.java
+++ b/src/main/java/com/monumental/models/suggestions/UpdateMonumentSuggestion.java
@@ -25,6 +25,12 @@ public class UpdateMonumentSuggestion extends MonumentSuggestion {
     @Column(name = "new_address")
     private String newAddress;
 
+    @Column(name = "new_city")
+    private String newCity;
+
+    @Column(name = "new_state")
+    private String newState;
+
     @Column(name = "new_artist")
     private String newArtist;
 
@@ -158,6 +164,22 @@ public class UpdateMonumentSuggestion extends MonumentSuggestion {
 
     public void setNewAddress(String newAddress) {
         this.newAddress = newAddress;
+    }
+
+    public String getNewCity() {
+        return this.newCity;
+    }
+
+    public void setNewCity(String newCity) {
+        this.newCity = newCity;
+    }
+
+    public String getNewState() {
+        return this.newState;
+    }
+
+    public void setNewState(String newState) {
+        this.newState = newState;
     }
 
     public String getNewArtist() {

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -948,7 +948,7 @@ public class MonumentService extends ModelService<Monument> {
         // Update basic String fields
         this.setBasicFieldsOnMonument(currentMonument, updateSuggestion.getNewTitle(), updateSuggestion.getNewAddress(),
                 updateSuggestion.getNewArtist(), updateSuggestion.getNewDescription(), updateSuggestion.getNewInscription(),
-                updateSuggestion.getMonument().getCity(), updateSuggestion.getMonument().getState());
+                updateSuggestion.getNewCity(), updateSuggestion.getNewState());
 
         // Update the Coordinates
         Point point = MonumentService.createMonumentPoint(updateSuggestion.getNewLongitude(), updateSuggestion.getNewLatitude());

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceIntegrationTests.java
@@ -3506,6 +3506,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3517,8 +3519,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
 
         assertEquals(1, monument.getContributions().size());
 
@@ -3545,6 +3547,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3557,8 +3561,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(1, monument.getContributions().size());
@@ -3590,6 +3594,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3604,8 +3610,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -3642,6 +3648,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3657,8 +3665,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -3702,6 +3710,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3717,8 +3727,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -3762,6 +3772,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3778,8 +3790,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -3823,6 +3835,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3847,8 +3861,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -3912,6 +3926,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -3936,8 +3952,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4001,6 +4017,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4030,8 +4048,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4108,6 +4126,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4139,8 +4159,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4214,6 +4234,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4253,8 +4275,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4349,6 +4371,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4388,8 +4412,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4492,6 +4516,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4532,8 +4558,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4636,6 +4662,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4681,8 +4709,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4785,6 +4813,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4830,8 +4860,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -4917,6 +4947,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -4964,8 +4996,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5076,6 +5108,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5123,8 +5157,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5250,6 +5284,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5300,8 +5336,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5411,6 +5447,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5464,8 +5502,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5579,6 +5617,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5634,8 +5674,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5749,6 +5789,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5803,8 +5845,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -5918,6 +5960,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -5980,8 +6024,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -6098,6 +6142,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -6162,8 +6208,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -6280,6 +6326,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -6343,8 +6391,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", monument.getArtist());
         assertEquals("New Description", monument.getDescription());
         assertEquals("New Inscription", monument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, monument.getLon(), 0.0);
@@ -6461,6 +6509,8 @@ public class MonumentServiceIntegrationTests {
         updateSuggestion.setMonument(monument);
         updateSuggestion.setNewTitle("New Title");
         updateSuggestion.setNewAddress("New Address");
+        updateSuggestion.setNewCity("New City");
+        updateSuggestion.setNewState("New State");
         updateSuggestion.setNewArtist("New Artist");
         updateSuggestion.setNewDescription("New Description");
         updateSuggestion.setNewInscription("New Inscription");
@@ -6526,8 +6576,8 @@ public class MonumentServiceIntegrationTests {
         assertEquals("New Artist", updatedMonument.getArtist());
         assertEquals("New Description", updatedMonument.getDescription());
         assertEquals("New Inscription", updatedMonument.getInscription());
-        assertEquals("City", monument.getCity());
-        assertEquals("State", monument.getState());
+        assertEquals("New City", monument.getCity());
+        assertEquals("New State", monument.getState());
         assertTrue(monument.getIsTemporary());
 
         assertEquals(95.0, updatedMonument.getLon(), 0.0);


### PR DESCRIPTION
This update automatically geocodes addresses/reverse geocodes coordinates when they're input on the create/update form, then displays the coordinates/address/city/state to the user (city/state un-editable) and sends them in the update to the server so they're stored.

No need to geocode/reverse geocode on the backend for singular create/update now, only for bulk


Address
![](https://i.imgur.com/roydPeP.png)

Coordinates
![](https://i.imgur.com/7RzLPmS.png)