### PR TITLE
Bug Fixes Round 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 /build/
 !gradle/wrapper/gradle-wrapper.jar
+keystore.p12
 
 ### SSL ###
 *.p12

--- a/client/src/components/AdminPanel/ManageMonuments/ManageMonuments.scss
+++ b/client/src/components/AdminPanel/ManageMonuments/ManageMonuments.scss
@@ -71,7 +71,7 @@
     }
 
     .update-monument-page-container {
-        .column.left {
+        .column.left, .column:last-child {
             display: none;
         }
         .create-form-container {

--- a/client/src/components/AdminPanel/ManageMonuments/ManageMonuments.scss
+++ b/client/src/components/AdminPanel/ManageMonuments/ManageMonuments.scss
@@ -71,7 +71,7 @@
     }
 
     .update-monument-page-container {
-        .thank-you-column {
+        .column.left {
             display: none;
         }
         .create-form-container {

--- a/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearch.js
+++ b/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearch.js
@@ -10,10 +10,12 @@ export default class SuggestionSearch extends React.Component {
         const { showSearchResults, onLimitChange, onPageChange, limit, page, count, suggestions } = this.props;
         const pageCount = Math.ceil(count / limit);
 
+        console.log(page);
+
         return (
             <div className="suggestion-search">
                 <div className="sticky-top">
-                    <SuggestionSearchBar/>
+                    <SuggestionSearchBar page={page} limit={limit}/>
                     {showSearchResults &&
                         <div className="mt-2">
                             <SearchInfo onLimitChange={onLimitChange} limit={limit} page={page} count={count} hideSortBy/>

--- a/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearch.js
+++ b/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearch.js
@@ -10,8 +10,6 @@ export default class SuggestionSearch extends React.Component {
         const { showSearchResults, onLimitChange, onPageChange, limit, page, count, suggestions } = this.props;
         const pageCount = Math.ceil(count / limit);
 
-        console.log(page);
-
         return (
             <div className="suggestion-search">
                 <div className="sticky-top">

--- a/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearchBar/SuggestionSearchBar.js
+++ b/client/src/components/AdminPanel/ManageSuggestions/SuggestionSearch/SuggestionSearchBar/SuggestionSearchBar.js
@@ -32,7 +32,7 @@ class SuggestionSearchBar extends React.Component {
     }
 
     search() {
-        const { history } = this.props;
+        const { history, page, limit } = this.props;
         const { searchQuery, statusFilter, typeFilter } = this.state;
 
         search({
@@ -40,7 +40,9 @@ class SuggestionSearchBar extends React.Component {
             approved: statusFilter === 'approved',
             rejected: statusFilter === 'rejected',
             pending: statusFilter === 'pending',
-            type: typeFilter
+            type: typeFilter,
+            page,
+            limit
         }, history, '/panel/manage/suggestions/search');
     }
 

--- a/client/src/components/BulkCreateForm/BulkCreateForm.js
+++ b/client/src/components/BulkCreateForm/BulkCreateForm.js
@@ -186,7 +186,6 @@ export default class BulkCreateForm extends React.Component {
                         mappedField
                     }
                 }).filter(pair => pair);
-                console.log('made mapping', mapping);
                 this.setState({mapping, fields})
             });
     }

--- a/client/src/components/BulkCreateForm/BulkCreateForm.js
+++ b/client/src/components/BulkCreateForm/BulkCreateForm.js
@@ -164,6 +164,7 @@ export default class BulkCreateForm extends React.Component {
                     await this.setState({showFieldMapping: true});
                 }
                 const mapping = headers.map(header => {
+                    if (!header) return;
                     let mappedField = '';
                     for (let field of fields) {
                         // By default don't select images on CSV uploads since they don't work.
@@ -184,8 +185,8 @@ export default class BulkCreateForm extends React.Component {
                         originalField: header,
                         mappedField
                     }
-                });
-
+                }).filter(pair => pair);
+                console.log('made mapping', mapping);
                 this.setState({mapping, fields})
             });
     }
@@ -360,11 +361,13 @@ export default class BulkCreateForm extends React.Component {
                             <div className="column d-flex justify-content-end my-1">
                                 <Form.Control as="select" className="mr-3" value={pair.mappedField} onChange={event => {
                                     pair.mappedField = event.currentTarget.value;
-                                    mapping.forEach((currentPair, currentIndex) => {
-                                        if (currentPair.mappedField === pair.mappedField && index !== currentIndex) {
-                                            currentPair.mappedField = '';
-                                        }
-                                    });
+                                    if (pair.mappedField !== 'Do Not Map') {
+                                        mapping.forEach((currentPair, currentIndex) => {
+                                            if (currentPair.mappedField === pair.mappedField && index !== currentIndex) {
+                                                currentPair.mappedField = '';
+                                            }
+                                        });
+                                    }
                                     fields.forEach(field => {
                                         field.selected = !!mapping.find(currentPair => {
                                             return currentPair.mappedField === field.name;
@@ -491,7 +494,7 @@ export default class BulkCreateForm extends React.Component {
                         will <span className="font-weight-bold">not</span> be {pastTenseTerm.toLowerCase()}.
                         {warningCount > 0 &&
                             <span>
-                                Any rows with warnings will still be {pastTenseTerm.toLowerCase()}, but may have
+                                &nbsp;Any rows with warnings will still be {pastTenseTerm.toLowerCase()}, but may have
                                 non-critical issues that should be addressed with updates later.
                             </span>
                         }

--- a/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
+++ b/client/src/components/CreateOrUpdateForm/CreateOrUpdateForm.js
@@ -666,7 +666,7 @@ export default class CreateOrUpdateForm extends React.Component {
         /* If there was no 2 letter state code, we could end up with something longer like San Juan, so fallback to
            leaving the field blank if it's not 2 letters long
          */
-        if (state.length !== 2) {
+        if (state && state.length !== 2) {
             state = undefined;
         }
         address = result.formatted_address;

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -8,7 +8,7 @@ export default class Footer extends React.Component {
         return (
             <div className="footer">
                 <ul className="footer-content">
-                    <li>Monuments + Memorials © 2020</li>
+                    <li>Monuments + Memorials © {new Date().getFullYear()}</li>
                     <li>
                         <Link to="/resources">Resources</Link>
                     </li>

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -46,7 +46,7 @@ class Header extends React.Component {
     handleLogout() {
         const { onLogout, history } = this.props;
         // If the user is currently on an authenticated route, tell ProtectedRoute not to show the unauthorized banner
-        history.replace({
+        history.push({
             pathname: history.location.pathname,
             state: { suppressAuthenticationBanner: true }
         });

--- a/client/src/components/Header/Header.scss
+++ b/client/src/components/Header/Header.scss
@@ -40,7 +40,7 @@
         input.form-control {
             width: 100%;
             min-width: 150px;
-            padding: 1.05rem 1rem !important;
+            padding: 1.05rem 2rem 1.05rem 1rem !important;
         }
     }
 

--- a/client/src/components/Header/SearchBar/LocationSearch/LocationSearch.js
+++ b/client/src/components/Header/SearchBar/LocationSearch/LocationSearch.js
@@ -98,6 +98,7 @@ export default class LocationSearch extends React.Component {
                     value={searchQuery}
                     onChange={newSearchQuery => this.handleChange(newSearchQuery)}
                     onSelect={address => this.handleSelect(address)}
+                    onError={(status, clearSuggestions) => clearSuggestions()}
                     searchOptions={searchOptions}
                     highlightFirstSuggestion={true}>
                     {renderFunc}

--- a/client/src/components/Monument/Details/About/About.js
+++ b/client/src/components/Monument/Details/About/About.js
@@ -173,7 +173,7 @@ export default class About extends React.Component {
                 <div>
                     <span className="detail-label">Contributors:&nbsp;</span>
                     <ul>
-                        {contributors.map(contributor => (<li key={contributor.id}>{contributor}</li>))}
+                        {contributors.map(contributor => (<li key={contributor}>{contributor}</li>))}
                     </ul>
                 </div>
             )

--- a/client/src/components/Monument/Details/Address/Address.scss
+++ b/client/src/components/Monument/Details/Address/Address.scss
@@ -7,6 +7,7 @@
 .address-container {
   display: flex;
   width: max-content;
+  max-width: 100%;
 
   i {
     color: $primary;

--- a/client/src/components/Monument/Images/Gallery/Gallery.scss
+++ b/client/src/components/Monument/Images/Gallery/Gallery.scss
@@ -89,10 +89,16 @@
         .modal-content {
             max-height: 100%;
             height: 100%;
+            display: flex;
+            flex-direction: column;
+
+            .modal-header {
+                flex-grow: 1;
+            }
 
             .modal-body {
-                max-height: 100%;
-                height: 100%;
+                min-height: 0;
+                flex-grow: 1;
                 img {
                     max-height: 100%;
                     max-width: 100%;

--- a/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
+++ b/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
@@ -16,7 +16,7 @@ export default class Map extends React.Component {
             q = [monument.lat, monument.lon].join(',');
         }
 
-        q = escape(q);
+        q = encodeURIComponent(q);
 
         return (
             <iframe title="gmaps-iframe"

--- a/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
+++ b/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
@@ -9,7 +9,10 @@ export default class Map extends React.Component {
         const monument = this.props.monument;
 
         let q = monument.address;
-        if (monument.address && monument.address.includes('Unnamed Road') || (!q && monument.lat && monument.lon)) {
+        if ((monument.address &&
+            (monument.address.includes('Unnamed Road') ||
+            monument.address.startsWith([monument.city, monument.state].join(', ')))) ||
+            (!q && monument.lat && monument.lon)) {
             q = [monument.lat, monument.lon].join(',');
         }
 

--- a/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
+++ b/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
@@ -13,6 +13,8 @@ export default class Map extends React.Component {
             q = [monument.lat, monument.lon].join(',');
         }
 
+        q = escape(q);
+
         return (
             <iframe title="gmaps-iframe"
                     src={`https://maps.google.com/maps?q=${q}&z=16&output=embed`}

--- a/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
+++ b/client/src/components/Monument/MapPhotoSphereTabs/Map/Map.js
@@ -9,7 +9,9 @@ export default class Map extends React.Component {
         const monument = this.props.monument;
 
         let q = monument.address;
-        if (!q && monument.lat && monument.lon) q = [monument.lat, monument.lon].join(',');
+        if (monument.address && monument.address.includes('Unnamed Road') || (!q && monument.lat && monument.lon)) {
+            q = [monument.lat, monument.lon].join(',');
+        }
 
         return (
             <iframe title="gmaps-iframe"

--- a/client/src/components/Suggestions/BulkCreateMonumentSuggestions/BulkCreateMonumentSuggestion/BulkCreateMonumentSuggestion.js
+++ b/client/src/components/Suggestions/BulkCreateMonumentSuggestions/BulkCreateMonumentSuggestion/BulkCreateMonumentSuggestion.js
@@ -1,38 +1,52 @@
 import * as React from 'react';
 import './BulkCreateMonumentSuggestion.scss';
+import { connect } from 'react-redux';
 import { Card } from 'react-bootstrap';
 import CreateMonumentSuggestions from '../../CreateMonumentSuggestions/CreateMonumentSuggestions';
 import { Link } from 'react-router-dom';
 import { getUserFullName } from '../../../../utils/string-util';
+import { Role } from '../../../../utils/authentication-util';
 
 /**
  * Presentational component for displaying a BulkCreateMonumentSuggestion
  */
-export default class BulkCreateMonumentSuggestion extends React.Component {
+class BulkCreateMonumentSuggestion extends React.Component {
+
+    static mapStateToProps(state) {
+        return {
+            session: state.session
+        };
+    }
 
     render() {
         const { suggestion, index, showTitleAsLink, showIndex=true, displayCreateMonumentStatuses,
-            showCreateTitlesAsLinks, showCreatedBy } = this.props;
+            showCreateTitlesAsLinks, showCreatedBy, session } = this.props;
 
         const titleText = showIndex ?
             `${index}. ${suggestion.fileName}` :
             `Create many new records from: ${suggestion.fileName}`;
 
         const manageUserLink = (
-            <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`} key={suggestion.createdBy.id}>
-                {getUserFullName(suggestion.createdBy)}
-            </Link>
+            session.user.role === Role.ADMIN ?
+                <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`} key={suggestion.createdBy.id}>
+                    {getUserFullName(suggestion.createdBy)}
+                </Link> :
+                <span>
+                    {getUserFullName(suggestion.createdBy)}
+                </span>
         );
 
         return (
             <Card className="bulk-create-suggestion">
                 <Card.Header className="bulk-create-suggestion-header pt-0">
                     <Card.Title>
-                        {
-                            showTitleAsLink ?
-                                <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=bulk`}>{titleText}</Link> :
-                                titleText
-                        }
+                        <span className="pr-3">
+                            {
+                                showTitleAsLink ?
+                                    <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=bulk`}>{titleText}</Link> :
+                                    titleText
+                            }
+                        </span>
                         {showCreatedBy &&
                             <div className="created-by-container">
                                 Created By:&nbsp;
@@ -54,3 +68,5 @@ export default class BulkCreateMonumentSuggestion extends React.Component {
         );
     }
 }
+
+export default connect(BulkCreateMonumentSuggestion.mapStateToProps)(BulkCreateMonumentSuggestion);

--- a/client/src/components/Suggestions/CreateMonumentSuggestions/CreateMonumentSuggestion/CreateMonumentSuggestion.js
+++ b/client/src/components/Suggestions/CreateMonumentSuggestions/CreateMonumentSuggestion/CreateMonumentSuggestion.js
@@ -1,21 +1,29 @@
 import * as React from 'react';
 import './CreateMonumentSuggestion.scss';
+import { connect } from 'react-redux';
 import { Card, Collapse } from 'react-bootstrap';
 import { getUserFullName, prettyPrintDate, prettyPrintMonth } from '../../../../utils/string-util';
 import Thumbnails from '../../../Monument/Images/Thumbnails/Thumbnails';
 import { Link } from 'react-router-dom';
 import SuggestionStatus from '../../../AdminPanel/ManageSuggestions/ManageSuggestion/SuggestionStatus/SuggestionStatus';
+import { Role } from '../../../../utils/authentication-util';
 
 /**
  * Presentational component for displaying a CreateMonumentSuggestion
  */
-export default class CreateMonumentSuggestion extends React.Component {
+class CreateMonumentSuggestion extends React.Component {
 
     constructor(props) {
         super(props);
 
         this.state = {
             expanded: props.expandedByDefault || false
+        };
+    }
+
+    static mapStateToProps(state) {
+        return {
+            session: state.session
         };
     }
 
@@ -162,27 +170,33 @@ export default class CreateMonumentSuggestion extends React.Component {
     }
 
     render() {
-        const { suggestion, index, showTitleAsLink, showIndex=true, showCreatedBy } = this.props;
+        const { suggestion, index, showTitleAsLink, showIndex=true, showCreatedBy, session } = this.props;
 
         const titleText = showIndex ?
             `${index}. ${suggestion.title}` :
             `Create new record: ${suggestion.title}`;
 
         const manageUserLink = (
-            <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`} key={suggestion.createdBy.id}>
-                {getUserFullName(suggestion.createdBy)}
-            </Link>
+            session.user.role === Role.ADMIN ?
+                <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`} key={suggestion.createdBy.id}>
+                    {getUserFullName(suggestion.createdBy)}
+                </Link> :
+                <span>
+                    {getUserFullName(suggestion.createdBy)}
+                </span>
         );
 
         return (
             <Card className="create-suggestion">
                 <Card.Header className="pt-0">
                     <Card.Title>
-                        {
-                            showTitleAsLink ?
-                                <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=create`}>{titleText}</Link> :
-                                titleText
-                        }
+                        <span className="pr-3">
+                            {
+                                showTitleAsLink ?
+                                    <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=create`}>{titleText}</Link> :
+                                    titleText
+                            }
+                        </span>
                         {showCreatedBy &&
                             <div className="created-by-container">
                                 Created By:&nbsp;
@@ -198,3 +212,5 @@ export default class CreateMonumentSuggestion extends React.Component {
         );
     }
 }
+
+export default connect(CreateMonumentSuggestion.mapStateToProps)(CreateMonumentSuggestion);

--- a/client/src/components/Suggestions/UpdateMonumentSuggestions/UpdateMonumentSuggestion/UpdateMonumentSuggestion.js
+++ b/client/src/components/Suggestions/UpdateMonumentSuggestions/UpdateMonumentSuggestion/UpdateMonumentSuggestion.js
@@ -1,11 +1,19 @@
 import * as React from 'react';
 import './UpdateMonumentSuggestion.scss';
+import { connect } from 'react-redux';
 import { Card } from 'react-bootstrap';
 import MonumentUpdate from '../../../Monument/Update/MonumentUpdate';
 import { Link } from 'react-router-dom';
 import { getUserFullName } from '../../../../utils/string-util';
+import { Role } from '../../../../utils/authentication-util';
 
-export default class UpdateMonumentSuggestion extends React.Component {
+class UpdateMonumentSuggestion extends React.Component {
+
+    static mapStateToProps(state) {
+        return {
+            session: state.session
+        };
+    }
 
     determineDateTypeForUpdate() {
         const { suggestion } = this.props;
@@ -49,7 +57,7 @@ export default class UpdateMonumentSuggestion extends React.Component {
 
     render() {
         const { suggestion, index, showTitleAsLink, showIndex=true, expandedByDefault, showCollapseLinks,
-            showCreatedBy } = this.props;
+            showCreatedBy, session } = this.props;
 
         let titleText;
         if (suggestion && suggestion.monument && suggestion.monument.title) {
@@ -59,20 +67,26 @@ export default class UpdateMonumentSuggestion extends React.Component {
         }
 
         const manageUserLink = (
-            <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`}>
-                {getUserFullName(suggestion.createdBy)}
-            </Link>
+            session.user.role === Role.ADMIN ?
+                <Link to={`/panel/manage/users/user/${suggestion.createdBy.id}`} key={suggestion.createdBy.id}>
+                    {getUserFullName(suggestion.createdBy)}
+                </Link> :
+                <span>
+                    {getUserFullName(suggestion.createdBy)}
+                </span>
         );
 
         return (
             <Card className="update-suggestion">
                 <Card.Header className="pt-0">
                     <Card.Title>
-                        {
-                            showTitleAsLink ?
-                                <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=update`}>{titleText}</Link> :
-                                titleText
-                        }
+                        <span className="pr-3">
+                            {
+                                showTitleAsLink ?
+                                    <Link to={`/panel/manage/suggestions/suggestion/${suggestion.id}?type=update`}>{titleText}</Link> :
+                                    titleText
+                            }
+                        </span>
                         {showCreatedBy &&
                             <div className="created-by-container">
                                 Created By:&nbsp;
@@ -91,3 +105,5 @@ export default class UpdateMonumentSuggestion extends React.Component {
         );
     }
 }
+
+export default connect(UpdateMonumentSuggestion.mapStateToProps)(UpdateMonumentSuggestion);

--- a/client/src/containers/ProtectedRoute/ProtectedRoute.js
+++ b/client/src/containers/ProtectedRoute/ProtectedRoute.js
@@ -44,7 +44,7 @@ class ProtectedRoute extends React.Component {
 
         // If you log out while on a restricted page, this will instantly redirect back to the homepage
         if (!loggedIn && active) {
-            return noAccessRedirect(`You must be logged in to view that page. <a href="/login?warn=true&redirect=${encodeURIComponent(path)}">Click here</a> to login.`);
+            return noAccessRedirect(`You must be logged in to view that page. <a href="/login?warn=true&redirect=${encodeURIComponent(history.location.pathname + history.location.search)}">Click here</a> to login.`);
         }
 
         // In all other cases, we pass our action to the render function of the route rather than instantly redirect,

--- a/client/src/pages/AdminPage/ManageSuggestionsPage/SuggestionSearchPage/SuggestionSearchPage.js
+++ b/client/src/pages/AdminPage/ManageSuggestionsPage/SuggestionSearchPage/SuggestionSearchPage.js
@@ -73,7 +73,9 @@ class SuggestionSearchPage extends React.Component {
             this.setState({type: params.type});
         }
         if (prevProps.location.search !== search) {
-            dispatch(searchSuggestions(QueryString.parse(search)));
+            const queryParams = QueryString.parse(search);
+            this.setState({...queryParams});
+            dispatch(searchSuggestions(queryParams));
         }
     }
 
@@ -94,7 +96,7 @@ class SuggestionSearchPage extends React.Component {
 
     async search(changedState) {
         await this.setState({changedState});
-        search(this.state, this.props.history, '/panel/manage/suggestions/search');
+        search({...this.state, ...changedState}, this.props.history, '/panel/manage/suggestions/search');
     }
 
     render() {

--- a/client/src/pages/AdminPage/ManageSuggestionsPage/SuggestionSearchPage/SuggestionSearchPage.js
+++ b/client/src/pages/AdminPage/ManageSuggestionsPage/SuggestionSearchPage/SuggestionSearchPage.js
@@ -95,8 +95,8 @@ class SuggestionSearchPage extends React.Component {
     }
 
     async search(changedState) {
-        await this.setState({changedState});
-        search({...this.state, ...changedState}, this.props.history, '/panel/manage/suggestions/search');
+        await this.setState(changedState);
+        search(this.state, this.props.history, '/panel/manage/suggestions/search');
     }
 
     render() {

--- a/client/src/pages/HomePage/HomePage.js
+++ b/client/src/pages/HomePage/HomePage.js
@@ -18,7 +18,7 @@ class HomePage extends React.Component {
 
     handleSuggestChangesButtonClick() {
         const { history } = this.props;
-        history.replace('/create');
+        history.push('/create');
     }
 
     static mapStateToProps(state) {

--- a/client/src/pages/MonumentPage/MonumentPage.js
+++ b/client/src/pages/MonumentPage/MonumentPage.js
@@ -24,18 +24,23 @@ class MonumentPage extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        const { dispatch, session, match: { params: { monumentId } } } = this.props;
+        const { dispatch, session, match: { params: { monumentId, slug } } } = this.props;
         if ((prevProps.session.pending && !session.pending && session.user) ||
             (prevProps.monument.id !== this.props.monument.id && this.props.monument.id)) {
             dispatch(fetchFavorite(monumentId));
+        }
+        if (prevProps.monument.id && !this.props.monument.id) {
+            dispatch(fetchMonument(monumentId));
+        }
+        if (this.props.monument.title && !slug) {
+            // Change the url to include the slug if it's not present
+            this.redirectToSlug();
         }
     }
 
     componentDidMount() {
         const { dispatch, match: { params: { monumentId } } } = this.props;
         dispatch(fetchMonument(monumentId));
-        // Change the url to include the slug if it's not present
-        this.redirectToSlug();
     }
 
     /**

--- a/client/src/pages/MonumentPage/MonumentPage.js
+++ b/client/src/pages/MonumentPage/MonumentPage.js
@@ -58,7 +58,7 @@ class MonumentPage extends React.Component {
         });
         // Don't redirect if the correct slug is already present
         if (slug !== newSlug) {
-            history.replace(`/monuments/${monument.id}/${newSlug}`);
+            history.push(`/monuments/${monument.id}/${newSlug}`);
         }
     }
 
@@ -73,7 +73,7 @@ class MonumentPage extends React.Component {
 
     handleSuggestChangesButtonClick() {
         const { monument, history } = this.props;
-        history.replace(`/update-monument/${monument.id}`)
+        history.push(`/update-monument/${monument.id}`);
     }
 
     render() {

--- a/client/src/pages/ResourcePage/ResourcePage.js
+++ b/client/src/pages/ResourcePage/ResourcePage.js
@@ -232,7 +232,7 @@ export default class ResourcePage extends React.Component {
                 <p>
                     To obtain coordinates, use the Google Maps “What’s here?” feature.
                 </p>
-                <img src="/resources/how-to-convert-degrees.png" className="example-image"/>
+                <img src="/resources/how-to-convert-degrees.png" className="example-image" alt="How To Obtain Coordinates"/>
                 <p>
                     Or, input address here: <a href="https://www.latlong.net/">https://www.latlong.net/</a>
                 </p>

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -44,7 +44,11 @@ class SearchPage extends React.Component {
     componentDidUpdate(prevProps, prevState, snapshot) {
         const { dispatch, location: { search } } = this.props;
         if (prevProps.location.search !== search) {
-            dispatch(searchMonuments(QueryString.parse(search)));
+            const params = QueryString.parse(search);
+            dispatch(searchMonuments(params));
+            this.setState({
+                ...params
+            });
         }
     }
 

--- a/client/src/pages/SuggestionCreatedPage/SuggestionCreatedPage.js
+++ b/client/src/pages/SuggestionCreatedPage/SuggestionCreatedPage.js
@@ -18,10 +18,10 @@ class SuggestionCreatedPage extends React.Component {
 
         switch (type) {
             case 'create':
-                history.replace('/create');
+                history.push('/create');
                 break;
             case 'bulk':
-                history.replace('/panel/bulk');
+                history.push('/panel/bulk');
                 break;
             default:
                 return;

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.js
@@ -6,6 +6,7 @@ import Spinner from '../../components/Spinner/Spinner';
 import Tags from '../../components/Tags/Tags';
 import { Helmet } from 'react-helmet';
 import Footer from '../../components/Footer/Footer';
+import { Button } from 'react-bootstrap';
 
 /**
  * Root container component for the Tag Directory Page
@@ -92,17 +93,15 @@ class TagDirectoryPage extends React.Component {
         return (
             <div className="alphanumeric-filter">
                 <span className={`character${alphanumericFilter === '' ? ' selected' : ''}`}>
-                    <a href="javascript:void();"
-                       onClick={() => this.setState({alphanumericFilter: ''})}>
+                    <Button variant="link" onClick={() => this.setState({alphanumericFilter: ''})}>
                         All
-                    </a>
+                    </Button>
                 </span>
                 {characters.map(character => (
                     <span key={character} className={`character${alphanumericFilter === character ? ' selected' : ''}`}>
-                        <a href="javascript:void();"
-                           onClick={() => this.setState({alphanumericFilter: character})}>
+                        <Button variant="link" onClick={() => this.setState({alphanumericFilter: character})}>
                             {character.toUpperCase()}
-                        </a>
+                        </Button>
                     </span>
                 ))}
             </div>

--- a/client/src/pages/TagDirectoryPage/TagDirectoryPage.scss
+++ b/client/src/pages/TagDirectoryPage/TagDirectoryPage.scss
@@ -9,7 +9,7 @@
         margin-bottom: 4rem;
 
         .character {
-            &.selected a {
+            &.selected .btn-link {
                 background-color: $primary;
                 color: white;
                 font-weight: 500;
@@ -20,7 +20,7 @@
                 margin: 0 0.25rem;
                 cursor: default;
             }
-            a {
+            .btn-link {
                 padding: 0 0.25rem;
             }
         }

--- a/client/src/reducers/monument.js
+++ b/client/src/reducers/monument.js
@@ -96,6 +96,7 @@ export function monumentPage(state = initialState, action) {
                 fetchFavoriteError: action.error
             };
         case LOCATION_CHANGE:
+            console.log(`location change ${window.location}`);
             return initialState;
         default:
             return state;

--- a/client/src/reducers/monument.js
+++ b/client/src/reducers/monument.js
@@ -96,7 +96,6 @@ export function monumentPage(state = initialState, action) {
                 fetchFavoriteError: action.error
             };
         case LOCATION_CHANGE:
-            console.log(`location change ${window.location}`);
             return initialState;
         default:
             return state;

--- a/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
+++ b/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
@@ -36,7 +36,7 @@ public class ProductionHTTPRedirect {
         connector.setScheme("http");
         connector.setPort(8080);
         connector.setSecure(false);
-        connector.setRedirectPort(8443);
+        connector.setRedirectPort(443);
         return connector;
     }
 }

--- a/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
+++ b/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
@@ -1,0 +1,42 @@
+package com.monumental.security;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.descriptor.web.SecurityCollection;
+import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("production")
+@Configuration
+public class ProductionHTTPRedirect {
+
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
+            @Override
+            protected void postProcessContext(Context context) {
+                SecurityConstraint securityConstraint = new SecurityConstraint();
+                securityConstraint.setUserConstraint("CONFIDENTIAL");
+                SecurityCollection collection = new SecurityCollection();
+                collection.addPattern("/*");
+                securityConstraint.addCollection(collection);
+                context.addConstraint(securityConstraint);
+            }
+        };
+        tomcat.addAdditionalTomcatConnectors(redirectConnector());
+        return tomcat;
+    }
+
+    private Connector redirectConnector() {
+        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        connector.setScheme("http");
+        connector.setPort(8080);
+        connector.setSecure(false);
+        connector.setRedirectPort(8443);
+        return connector;
+    }
+}

--- a/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
+++ b/src/main/java/com/monumental/security/ProductionHTTPRedirect.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+/**
+ * This class is responsible for redirecting HTTP requests from port 8080 to HTTPS on port 443
+ */
 @Profile("production")
 @Configuration
 public class ProductionHTTPRedirect {
@@ -27,7 +30,7 @@ public class ProductionHTTPRedirect {
                 context.addConstraint(securityConstraint);
             }
         };
-        tomcat.addAdditionalTomcatConnectors(redirectConnector());
+        tomcat.addAdditionalTomcatConnectors(this.redirectConnector());
         return tomcat;
     }
 

--- a/src/main/java/com/monumental/services/GoogleMapsService.java
+++ b/src/main/java/com/monumental/services/GoogleMapsService.java
@@ -23,6 +23,12 @@ public class GoogleMapsService {
         public Geometry geometry;
     }
 
+    /**
+     * Get an address along with city and state from the specified coordinates using Google Maps
+     * @param lat - latitude
+     * @param lon - longitude
+     * @return AddressBundle - Bundle including address, city, and state
+     */
     public AddressBundle getAddressFromCoordinates(Double lat, Double lon) {
         try {
             GeoApiContext context = this.buildGeoApiContext();
@@ -42,9 +48,9 @@ public class GoogleMapsService {
     }
 
     /**
-     * Get a set of coordinates from the specified address using Google Maps
+     * Get a set of coordinates along with city and state from the specified address using Google Maps
      * @param address - String for the address to geocode
-     * @return Geometry - Google Maps Geometry containing the location data for the address
+     * @return AddressBundle - Bundle including Google Maps Geometry containing the location data for the address
      */
     public AddressBundle getCoordinatesFromAddress(String address) {
         if (StringHelper.isNullOrEmpty(address)) {
@@ -69,6 +75,12 @@ public class GoogleMapsService {
         return null;
     }
 
+    /**
+     * Takes a GeocodingResult and parses it for address, city, state, and geometry data, then packages it in
+     * an AddressBundle
+     * @param result - GeocodingResult from a Google Maps Geocoding or Reverse-Geocoding request
+     * @return AddressBundle - The bundle of address, geometry, city, and state data
+     */
     private AddressBundle buildBundle(GeocodingResult result) {
         AddressBundle bundle = new AddressBundle();
         String country = null;

--- a/src/main/java/com/monumental/services/GoogleMapsService.java
+++ b/src/main/java/com/monumental/services/GoogleMapsService.java
@@ -110,7 +110,7 @@ public class GoogleMapsService {
         /* If there was no 2 letter state code, we could end up with something longer like San Juan, so fallback to
            leaving the field blank if it's not 2 letters long
          */
-        if (bundle.state == null || bundle.state.length() != 2) {
+        if (bundle.state != null && bundle.state.length() != 2) {
             bundle.state = null;
         }
 

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -114,7 +114,7 @@ public class MonumentService extends ModelService<Monument> {
                 builder.desc(
                     builder.sum(
                         builder.sum(
-                            SearchHelper.buildSimilarityExpression(builder, root, searchQuery, "title"),
+                            builder.prod(SearchHelper.buildSimilarityExpression(builder, root, searchQuery, "title"), 3),
                             SearchHelper.buildSimilarityExpression(builder, root, searchQuery, "artist")
                         ),
                         SearchHelper.buildSimilarityExpression(builder, root, searchQuery, "description")

--- a/src/main/java/com/monumental/services/MonumentService.java
+++ b/src/main/java/com/monumental/services/MonumentService.java
@@ -1379,7 +1379,7 @@ public class MonumentService extends ModelService<Monument> {
     public void populateNewMonumentLocation(Monument monument) {
         // If the Monument has no address, do a reverse geocode
         if (monument.getAddress() == null && monument.getCoordinates() != null) {
-            GoogleMapsService.AddressBundle bundle = googleMapsService.getAddressFromCoordinates(monument.getLat(), monument.getLon());
+            GoogleMapsService.AddressBundle bundle = this.googleMapsService.getAddressFromCoordinates(monument.getLat(), monument.getLon());
             if (bundle != null) {
                 monument.setAddress(bundle.address);
                 monument.setCity(bundle.city);
@@ -1454,7 +1454,7 @@ public class MonumentService extends ModelService<Monument> {
         }
 
         // Perform reverse geocoding
-        GoogleMapsService.AddressBundle bundle = googleMapsService.getAddressFromCoordinates(newMonument.getLat(), newMonument.getLon());
+        GoogleMapsService.AddressBundle bundle = this.googleMapsService.getAddressFromCoordinates(newMonument.getLat(), newMonument.getLon());
         if (bundle != null) {
             newMonument.setAddress(bundle.address);
             newMonument.setCity(bundle.city);

--- a/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
+++ b/src/main/java/com/monumental/util/csvparsing/CsvMonumentConverter.java
@@ -93,7 +93,7 @@ public class CsvMonumentConverter {
                                 if (latitude > 72 || latitude < -15) {
                                     result.getErrors().add("Latitude is not near the United States");
                                 }
-                                // If the not a valid latitude, set it to null because extremely large values can break everything
+                                // If not a valid latitude, set it to null because extremely large values can break everything
                                 if (latitude > 90 || latitude < -90) {
                                     latitude = null;
                                 }
@@ -118,7 +118,7 @@ public class CsvMonumentConverter {
                                 if (longitude > -64 && !(longitude < 180 && longitude > 143)) {
                                     result.getErrors().add("Longitude is not near the United States");
                                 }
-                                // If the not a valid longitude, set it to null because extremely large values can break everything
+                                // If not a valid longitude, set it to null because extremely large values can break everything
                                 if (longitude > 180 || longitude < -180) {
                                     longitude = null;
                                 }

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
@@ -11,6 +11,7 @@ import com.monumental.repositories.suggestions.BulkCreateSuggestionRepository;
 import com.monumental.repositories.suggestions.CreateSuggestionRepository;
 import com.monumental.services.AwsS3Service;
 import com.monumental.services.MonumentService;
+import com.monumental.util.csvparsing.CsvMonumentConverter;
 import com.monumental.util.csvparsing.CsvMonumentConverterResult;
 import com.monumental.util.csvparsing.MonumentBulkValidationResult;
 import com.opencsv.CSVReader;
@@ -187,7 +188,7 @@ public class MonumentServiceMockIntegrationTests {
         CsvMonumentConverterResult validationErrors = validationResult.getInvalidResults().get(1);
 
         assertEquals(1, validationErrors.getWarnings().size());
-        assertTrue(validationErrors.getWarnings().contains("Please use decimal coordinates, not degrees. To convert, input your degrees into Google Maps."));
+        assertTrue(validationErrors.getWarnings().contains(CsvMonumentConverter.coordinatesDMSFormatWarning));
 
         assertEquals(2, validationErrors.getErrors().size());
         assertTrue(validationErrors.getErrors().contains("Title is required"));

--- a/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
+++ b/src/test/java/com/monumental/services/integrationtest/MonumentServiceMockIntegrationTests.java
@@ -186,7 +186,7 @@ public class MonumentServiceMockIntegrationTests {
 
         CsvMonumentConverterResult validationErrors = validationResult.getInvalidResults().get(1);
 
-        assertEquals(3, validationErrors.getWarnings().size());
+        assertEquals(1, validationErrors.getWarnings().size());
         assertTrue(validationErrors.getWarnings().contains("Please use decimal coordinates, not degrees. To convert, input your degrees into Google Maps."));
 
         assertEquals(2, validationErrors.getErrors().size());
@@ -336,9 +336,8 @@ public class MonumentServiceMockIntegrationTests {
         assertEquals(2, validationResult.getInvalidResults().size());
 
         CsvMonumentConverterResult validationErrorsRow2 = validationResult.getInvalidResults().get(2);
-        assertEquals(4, validationErrorsRow2.getErrors().size());
-        assertTrue(validationErrorsRow2.getErrors().contains("Latitude must be valid"));
-        assertTrue(validationErrorsRow2.getErrors().contains("Longitude must be valid"));
+        assertEquals(3, validationErrorsRow2.getErrors().size());
+        assertTrue(validationErrorsRow2.getErrors().contains("Address OR Coordinates are required"));
         assertTrue(validationErrorsRow2.getErrors().contains("Latitude is not near the United States"));
         assertTrue(validationErrorsRow2.getErrors().contains("Longitude is not near the United States"));
 

--- a/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterUnitTests.java
+++ b/src/test/java/com/monumental/util/csvparsing/unittests/CsvMonumentConverterUnitTests.java
@@ -402,7 +402,7 @@ public class CsvMonumentConverterUnitTests {
         assertEquals(2, materialNameResults.size());
         assertEquals(3, tagNameResults.size());
 
-        assertEquals(3, result.getWarnings().size());
+        assertEquals(1, result.getWarnings().size());
         assertEquals(1, result.getErrors().size());
     }
 


### PR DESCRIPTION
* Better handling of US territories for the State field
    * Google Maps considers Guam and Puerto Rico countries, so they don't show up in the same places states do. We now have a somewhat intelligent fallback mechanism where if the country has a 2 letter short code and the state didn't exist or wasn't 2 letters we use the country as the state
* Fixed search result numbers not changing after a filter change reset the page to 1 (you could have result 101 at the top of page 1 because of this)
* Show no results instead of old results if the LocationSearch got no results back
    * I wanted to show a "No results found" line but it doesn't seem possible with the package we're using
* Fix images overflowing the modal when you click to expand them on the monument page
* Fix a bunch of react warnings
* Fix monument page not querying for new monument after changing from one monument to another (related/nearby monuments, etc.)
* Fix the clear button in text/location search overlapping the text in the input
* Fix url not updating with monument slug on monument page
* Replace usages of `history.replace` with `history.push` so that you can go back in your browser
* When you try to access a protected route without being logged in, it sends to you the login page and will redirect you back after you login. For pages with path params this didn't work correctly, but it does now
* Fix null descriptions making score null in searches
* Add `word_similarity` to relevance search and make title 3x as important as artist or description
* Safely handle larger than acceptable latitude/longitudes in bulk upload (a value of over 90,000 was causing a fatal error)
* Improve latitude/longitude error handling so that you don't get cascading errors/warnings because of one fault. For example if you used degrees, you would get a warning about that and then an error because there was no value saved. Now, the error is suppressed and that warning is elevated to an error so that you still can't continue, but you aren't as confused by the messages
* Changed the copyright in the footer to automatically be the current year
* Allow "Do Not Map" to be selected multiple times in bulk upload mapping, just like "Select a field"
* Auto remove blank columns in bulk upload field mapping
* Redirect HTTP requests to HTTPS in production. This fixes that mysterious bug where typing monuments.us.org into your browser would get you nowhere
* Get city/state when geocoding/reverse geocoding on the backend, like we do already on the frontend