### PR TITLE
Fix Tag Redirects on Monument Page

### DIFF
--- a/client/src/components/Monument/Details/Details.js
+++ b/client/src/components/Monument/Details/Details.js
@@ -74,7 +74,7 @@ export default class Details extends React.Component {
                             }
                             <div className="field">{monument.description}</div>
                         </div>
-                        <Tags tags={tags}/>
+                        <Tags tags={tags} searchUri="/search"/>
                     </div>
                 </div>
                 <Gallery images={images}/>


### PR DESCRIPTION
This PR fixes the redirect link when a Tag is clicked on the Monument Page.