### PR TITLE
Bulk export all monuments fix

### DIFF
--- a/client/src/components/Export/ExportToCsvButton/ExportToCsvButton.js
+++ b/client/src/components/Export/ExportToCsvButton/ExportToCsvButton.js
@@ -13,16 +13,21 @@ export const ExportToCsvButton = (props) => {
 
     const handleClick = () => {
         const csv = exportToCsv(fields, data);
-        const encodedUri = encodeURI(csv);
-
-        const link = document.createElement('a');
-        link.setAttribute('href', encodedUri);
-
         const exportFileName = exportTitle.endsWith('.csv') ? exportTitle : exportTitle + '.csv';
-        link.setAttribute('download', exportFileName);
+        const blob = new Blob([csv]);
 
-        document.body.appendChild(link);
-        link.click();
+        if (navigator.msSaveBlob) { // For Microsoft Edge
+            navigator.msSaveBlob(blob, exportFileName);
+        } else {
+            const link = document.createElement("a");
+            if (link.download !== undefined) {
+                const url = URL.createObjectURL(blob);
+                link.setAttribute("href", url);
+                link.setAttribute("download", exportFileName);
+                document.body.appendChild(link);
+                link.click();
+            }
+        }
         rollbar.info(`Exported monuments (${data.length}) to CSV`);
     }
 

--- a/client/src/components/User/Favorites/Favorites.js
+++ b/client/src/components/User/Favorites/Favorites.js
@@ -18,7 +18,7 @@ export default class Favorites extends React.Component {
                         Your Favorites{favorites && favorites.length ? ` (${favorites.length})` : ''}
                         {favorites && <span className="export-buttons-favorites">
                             <ExportButtons className="mt-2"
-                                           monuments={favorites}
+                                           monuments={favorites.map(a => a.monument)}
                                            title="Favorites"/>
                         </span>}
                     </Card.Title>

--- a/client/src/utils/export-util.js
+++ b/client/src/utils/export-util.js
@@ -245,7 +245,7 @@ export function buildExportData(monument, fields=csvExportFields, pretty=false, 
  * @param data - Array of data representing the rows of the CSV
  */
 export function exportToCsv(fields, data) {
-    return 'data:text/csv;charset=utf-8,' + toCSV(data, {fields});
+    return toCSV(data, {fields});
 }
 
 /**


### PR DESCRIPTION
This branch fixes the following issues:

(1) As an admin, bulk export only exported a fraction of the total monuments.
(2) As a user, exporting favorites was not exporting the actual monuments. 